### PR TITLE
Display patch 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/CMakeFiles/
 build/Makefile
 build/cmake_install.cmake
 build/src/
+build/gmon.out


### PR DESCRIPTION
- disable the backing pixmap and double-buffering, we get a better
  result doing this ourselves
- fix up vips reference counting within imagearea
- use the vips_sink_screen() mask image to suppress painting of
  uncalculated pixels
  
  this fixes the nasty black "flash" we used to get when a toggle on the
  right was changed
- remove the invalidate stuff again, vips-7.39+ does not need this
  
  unless you use git master vips you'll see black pixels
  
  add a couple of vips_image_invalidate_all() calls for earlier vipses
