### PR TITLE
Frequent crashes (was: Add missing headers).

### DIFF
--- a/src/base/imagepyramid.cc
+++ b/src/base/imagepyramid.cc
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/base/rawbuffer.cc
+++ b/src/base/rawbuffer.cc
@@ -32,6 +32,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <stdlib.h>
 

--- a/src/base/rawbuffer.hh
+++ b/src/base/rawbuffer.hh
@@ -31,11 +31,12 @@
 #ifndef RAW_BUFFER_H
 #define RAW_BUFFER_H
 
+#include <unistd.h>
+
 #include <string>
 #include <vector>
 #include <iostream>
 #include <fstream>
-
 
 #include <vips/vips.h>
 #include <vips/vips>

--- a/src/operations/blender.hh
+++ b/src/operations/blender.hh
@@ -30,6 +30,8 @@
 #ifndef VIPS_BLENDER_H
 #define VIPS_BLENDER_H
 
+#include <unistd.h>
+
 #include <string>
 
 #include "../base/operation.hh"


### PR DESCRIPTION
We are missing some includes to compile with recent gcc.
