### PR TITLE
Gtk3: switch to the dark theme variant by default.

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -193,6 +193,8 @@ int main (int argc, char *argv[])
 
   PF::MainWindow* mainWindow = new PF::MainWindow();
 #ifdef GTKMM_3
+  Gtk::Settings::get_default()->property_gtk_application_prefer_dark_theme().set_value(true);
+
   int stat_result = stat((themesPath + "/photoflow-dark.css").c_str(), &buffer);
   if( stat_result == 0 ) {
     Glib::RefPtr<Gtk::CssProvider> css = Gtk::CssProvider::create();


### PR DESCRIPTION
Switch to the dark gtk theme by default. 
This already improves a lot issue #15 without changing your custom css.

As you can see, there is still a small problem with the tabs:
![photoflow](https://cloud.githubusercontent.com/assets/838332/6998837/0a9d8184-dbef-11e4-8526-801b6fedbf5a.png)
