### PR TITLE
Solve the memset FTBFS

### DIFF
--- a/src/operations/impulse_nr.cc
+++ b/src/operations/impulse_nr.cc
@@ -30,6 +30,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <string.h>
+#include <cstring>
 
 #include "gaussblur.hh"
 #include "../base/new_operation.hh"


### PR DESCRIPTION
This is a patch to avoid a FTBFS in Debian systems.