### PR TITLE
Update and extend build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ build/Makefile
 build/cmake_install.cmake
 build/src/
 build/gmon.out
+
+# hide VIPS' source tree
+libvips/

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,19 +1,114 @@
 #! /bin/bash
+#  Script:    build.sh
+#  Purpose:   Build PhotoFlow, create starter scripts.
+#  Call:      build.sh <Build-Type>
+#             Build-Type: debug for a Debug Build,
+#                         test  for a Test Build,
+#                         else for a Release Build.
+#  Environment Variables:
+#  BUILD_TYPE     : the Build-Type as above. Optional.
+#  INSTALL_PREFIX : the root directory for PhotoFlow's release, debug or test
+#                   builds.
+#                   Optional. If omitted, then this is the current directory.
+#  CMAKE_EXTRA_PARAMS:  extra parameters to control cmake, such as -DBUNDLED_GEVIV2=OFF.
+#  LD_LIBRARY_PATH: a colon-separated list of directories where libraries
+#                   should be searched before the standard directories.
+#                   If VIPS_INSTALL_PREFIX is set, then this variable will
+#                   be extended accordingly.
+#  PKG_CONFIG_PATH: see "man pkg-config".
+#                   If VIPS_INSTALL_PREFIX is set, then this variable will
+#                   be extended accordingly.
+#  VIPS_INSTALL_PREFIX: VIPS' install prefix. Optional.
+#                   If omitted, then the system's libvips is used.
+#  Author, License:
+#    Copyright (C) 2014, 2016 Ferrero Andrea, Sven Claussner
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-rm CMakeCache.txt
+# evaluate arguments and environment variables
+## Evaluate BUILD_TYPE and create uppercase and capitalized variants of it.
+## BUILD_TYPE: use environment variable BUILD_TYPE, $1 or Release (in this order)
+BUILD_TYPE=${BUILD_TYPE:-${1:-Release}}
+build_type_upper=$(echo ${BUILD_TYPE} | tr '[:lower:]' '[:upper:]')
+build_type_capital=$(echo ${BUILD_TYPE} | tr '[:upper:]' '[:lower:]' | sed 's/.*/\u&/')
+echo "build_type_upper:" $build_type_upper >log.txt
+echo "build_type_capital:" $build_type_capital >>log.txt
 
-if [ x"$1" = "xdebug" ]; then
-    #export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:PATH_TO_VIPS_INSTALL_WITH_DEBUG/lib/pkgconfig"
-    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(pwd)/Debug  -DINSTALL_PREFIX=$(pwd)/Debug ../
-    make VERBOSE=1 install
-elif [ x"$1" = "xtest" ]; then
-    #export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:PATH_TO_VIPS_INSTALL/lib/pkgconfig"
-    cmake -DCMAKE_BUILD_TYPE=Test -DCMAKE_INSTALL_PREFIX=$(pwd)/Test -DINSTALL_PREFIX=$(pwd)/Test ..
-    make install
-else
-    #export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:PATH_TO_VIPS_INSTALL/lib/pkgconfig"
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(pwd)/Release -DINSTALL_PREFIX=$(pwd)/Release ../
-    make install
+## evaluate INSTALL_PREFIX to determine the installation directory
+export INSTALL_PREFIX=${INSTALL_PREFIX:-$(pwd)}
+phf_install_prefix=${INSTALL_PREFIX}/${build_type_capital}
+
+# set LD_LIBRARY_PATH
+if [ -n "${VIPS_INSTALL_PREFIX}" ]; then
+    export PKG_CONFIG_PATH=${VIPS_INSTALL_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}
+    export LD_LIBRARY_PATH=${VIPS_INSTALL_PREFIX}/lib:${LD_LIBRARY_PATH}
 fi
 
+# clean up before building
+rm CMakeCache.txt
 
+echo "Building PhotoFlow..."
+echo "Install PhotoFlow to: ${phf_install_prefix}"
+echo "Build type: ${build_type_capital}"
+echo "Use VIPS in ${VIPS_INSTALL_PREFIX}"
+echo "PKG_CONFIG_PATH: ${PKG_CONFIG_PATH}"
+echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
+
+if [ "${build_type_upper}" = "TEST" ]; then
+# valid values for CMAKE_BUILD_TYPE:[DEBUG|RELEASE|RELWITHDEBINFO|MINSIZEREL]
+    cmake -DCMAKE_BUILD_TYPE=DEBUG \
+    -DCMAKE_INSTALL_PREFIX=${phf_install_prefix} \
+    -DINSTALL_PREFIX=${phf_install_prefix} \
+    ${CMAKE_EXTRA_PARAMS} \
+    .. &&
+    make VERBOSE=1 install
+else
+#  make Release, Debug and everything else except Test
+    cmake -DCMAKE_BUILD_TYPE=${build_type_upper} \
+    -DCMAKE_INSTALL_PREFIX=${phf_install_prefix} \
+    -DINSTALL_PREFIX=${phf_install_prefix} \
+    ${CMAKE_EXTRA_PARAMS} \
+    .. &&
+    make VERBOSE=1 install
+fi
+
+# If the build broke, then exit here with a message.
+return_code=$?
+if [ ${return_code} -ne 0 ]; then
+    echo "Building PhotoFlow finished with return code ${return_code}."
+    exit ${return_code}
+fi
+
+printf "Creating starter scripts to ensure Photoflow finds libvips: "
+printf "run_photoflow.sh, "
+cat <<EOF >${phf_install_prefix}/run_photoflow.sh
+#! /bin/bash
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+echo LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}
+${phf_install_prefix}/bin/photoflow
+echo Photoflow exited with code \$?.
+EOF
+chmod a+x ${phf_install_prefix}/run_photoflow.sh
+
+printf "run_pfbatch.sh.\n"
+cat << EOF >${phf_install_prefix}/run_pfbatch.sh
+#! /bin/bash
+export "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+echo LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}
+${phf_install_prefix}/bin/pfbatch
+echo Pfbatch exited with code \$?.
+EOF
+chmod a+x ${phf_install_prefix}/run_pfbatch.sh
+
+echo "Building PhotoFlow finished with return code $?."

--- a/build/build_all.sh
+++ b/build/build_all.sh
@@ -1,4 +1,6 @@
 #! /bin/bash
+#  UPDATE_VIPS    : 1 if VIPS shall be updated before build. Optional.
+#                   Enabled by default.
 
 vips_install=$(pwd)/VIPS/build
 rebuild_VIPS=1
@@ -40,11 +42,22 @@ if [ ${rebuild_VIPS} -eq 1 ]; then
 		fi
 
 		cd ../..
+## UPDATE_VIPS: use environment variable or default value 1.
+update_VIPS=${UPDATE_VIPS:-1}
+if [ ${update_VIPS} -eq 1 ]; then
+    echo "Update VIPS: yes"
+else
+    echo "Update VIPS: no"
 fi
 
 #rm -rf Release
 mkdir -p Release
 cd Release
+    # get update
+    if [ ${update_VIPS} -eq 1 ]; then
+        ../tools/update_libvips.sh
+    fi
+    cd ../libvips
 
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${vips_install}/lib/pkgconfig"
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(pwd) -DINSTALL_PREFIX=$(pwd) ../../ && make install

--- a/build/build_all.sh
+++ b/build/build_all.sh
@@ -14,11 +14,9 @@ if [ ${rebuild_VIPS} -eq 1 ]; then
         if [ -e libvips ]; then
             cd libvips
             git pull
-				    ./bootstrap.sh
         else
 				    git clone https://github.com/jcupitt/libvips.git
 				    cd libvips
-				    ./bootstrap.sh
         fi
     else
 				cd libvips
@@ -59,5 +57,7 @@ cd Release
     fi
     cd ../libvips
 
+    # run libvips bootstrapper
+    ./autogen.sh
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${vips_install}/lib/pkgconfig"
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(pwd) -DINSTALL_PREFIX=$(pwd) ../../ && make install

--- a/build/build_all.sh
+++ b/build/build_all.sh
@@ -1,45 +1,62 @@
 #! /bin/bash
+#  Script:    build_all.sh
+#  Purpose:   Update (optionally) and build libvips. Build PhotoFlow.
+#  Call:      build_all.sh <Build-Type>
+#             Build-Type: debug for a Debug Build,
+#                         test  for a Test Build,
+#                         else for a Release Build.
+#  Environment Variables:
+#  BUILD_TYPE     : the Build-Type as above. Optional.
+#  CLEAN_VIPS     : 1 if VIPS shall be built from scratch. Optional.
+#                   Disabled by default.
+#  INSTALL_PREFIX : the root directory for VIPS' and PhotoFlow's builds.
+#                   Optional. If omitted, then this is the current directory.
 #  UPDATE_VIPS    : 1 if VIPS shall be updated before build. Optional.
 #                   Enabled by default.
+#  BUILD_VIPS     : 1 if VIPS shall be built. Optional.
+#                   Enabled by default.
+#  Author, License:
+#    Copyright (C) 2014, 2016 Ferrero Andrea, Sven Claussner
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-vips_install=$(pwd)/VIPS/build
-rebuild_VIPS=1
-update_VIPS=1
-if [ ${rebuild_VIPS} -eq 1 ]; then
-		rm -rf ${vips_install}
-		mkdir -p ${vips_install}
-		cd VIPS
+# Evaluate arguments and environment variables.
+## BUILD_TYPE: use environment variable BUILD_TYPE, $1 or Release (in this order)
+BUILD_TYPE=${BUILD_TYPE:-${1:-Release}}
+## Capitalize build_type to tolerate misspellings.
+export BUILD_TYPE=\
+$(echo ${BUILD_TYPE} | tr '[:upper:]' '[:lower:]' | sed 's/.*/\u&/')
 
-		if [ ${update_VIPS} -eq 1 ]; then
-        if [ -e libvips ]; then
-            cd libvips
-            git pull
-        else
-				    git clone https://github.com/jcupitt/libvips.git
-				    cd libvips
-        fi
-    else
-				cd libvips
-		fi
+if [ "${BUILD_TYPE}" == "Debug" ]; then
+    vips_enable_debug="yes"
+else
+    vips_enable_debug="no"
+fi
 
-		FLAGS="-O2 -msse4.2 -ffast-math"
-		FLAGS="$FLAGS -ftree-vectorize"
-		CFLAGS="$FLAGS" CXXFLAGS="$FLAGS -fpermissive" \
-				./configure --prefix=${vips_install} --disable-gtk-doc --disable-gtk-doc-html \
-				--disable-introspection --enable-debug=no --without-python  --without-magick --without-libwebp\
-				--enable-pyvips8=no --enable-shared=no --enable-static=yes
-		if [ $? -ne 0 ]; then
-				echo "VIPS configure failed"
-				exit 1
-		fi
-    #make clean depclean
-		make install
-		if [ $? -ne 0 ]; then
-				echo "VIPS compilation failed"
-				exit 1
-		fi
+## INSTALL_PREFIX: use environment variable INSTALL_PREFIX or current directory
+## (in this order)
+export INSTALL_PREFIX=${INSTALL_PREFIX:-$(pwd)}
 
-		cd ../..
+## Install VIPS to a separate directory than PhotoFlow.
+export VIPS_INSTALL_PREFIX=${INSTALL_PREFIX}/VIPS/${BUILD_TYPE}
+
+## Report detected settings.
+echo Building VIPS...
+echo Install VIPS to: ${VIPS_INSTALL_PREFIX}
+echo Build type: ${BUILD_TYPE}
+echo Include debug information: ${vips_enable_debug}
+
 ## UPDATE_VIPS: use environment variable or default value 1.
 update_VIPS=${UPDATE_VIPS:-1}
 if [ ${update_VIPS} -eq 1 ]; then
@@ -48,9 +65,31 @@ else
     echo "Update VIPS: no"
 fi
 
-#rm -rf Release
-mkdir -p Release
-cd Release
+## CLEAN_VIPS: use environment variable or default value 0.
+clean_VIPS=${CLEAN_VIPS:-0}
+if [ ${clean_VIPS} -eq 1 ]; then
+    echo "Clean VIPS source directory: yes"
+else
+    echo "Clean VIPS source directory: no"
+fi
+
+## BUILD_VIPS: use environment variable or default value 1.
+build_VIPS=${BUILD_VIPS:-1}
+if [ ${build_VIPS} -eq 1 ]; then
+    echo "Build VIPS: yes"
+else
+    echo "Build VIPS: no"
+fi
+
+# Rebuild and conditionally update.
+if [ ${build_VIPS} -eq 1 ]; then
+    # store current directory
+    export OLD_PWD=$(pwd)
+
+    # clean up
+    rm -rf ${VIPS_INSTALL_PREFIX}
+    mkdir -p ${VIPS_INSTALL_PREFIX}
+
     # get update
     if [ ${update_VIPS} -eq 1 ]; then
         ../tools/update_libvips.sh
@@ -59,5 +98,40 @@ cd Release
 
     # run libvips bootstrapper
     ./autogen.sh
-export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${vips_install}/lib/pkgconfig"
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(pwd) -DINSTALL_PREFIX=$(pwd) ../../ && make install
+
+    export FLAGS="-O2 -msse4.2 -ffast-math"
+    export FLAGS="${FLAGS} -ftree-vectorize"
+    export CFLAGS="${FLAGS}"
+    export CXXFLAGS="${FLAGS} -fpermissive"
+    ./configure --prefix=${VIPS_INSTALL_PREFIX} \
+    --disable-gtk-doc --disable-gtk-doc-html \
+    --disable-introspection --enable-debug==${vips_enable_debug} \
+    --without-python --without-magick --without-libwebp \
+    --enable-pyvips8=no --enable-shared=yes --enable-static=no
+    if [ $? -ne 0 ]; then
+        echo "VIPS configure failed"
+        exit 1
+    fi
+
+    if [ ${clean_vips} -eq 1 ]; then
+        make clean depclean
+    fi
+
+    make
+    if [ $? -ne 0 ]; then
+        echo "VIPS compilation failed"
+        exit 1
+    fi
+
+    make install
+    if [ $? -ne 0 ]; then
+        echo "VIPS installation failed"
+        exit 1
+    fi
+
+    # change back to former directory
+    cd -
+fi
+
+# Exit this script and continue with the PhotoFlow build.
+exec ./build.sh

--- a/tools/update_libvips.sh
+++ b/tools/update_libvips.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+#  Script:  update_libvips.sh
+#  Purpose: Update libvips.
+#           If libvips is not here yet, clone it from Github.
+#           Otherwise run "git pull".
+#  Call:    update_libvips.sh
+#  Author, License:
+#    Copyright (C) 2014, 2016 Ferrero Andrea, Sven Claußner
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+libvips_dir="../libvips"
+
+export OLD_PWD=$(pwd)
+
+echo Updating VIPS...
+if [ -e ${libvips_dir} ]; then
+    cd ${libvips_dir}
+    git pull
+else
+    git clone https://github.com/jcupitt/libvips.git ${libvips_dir}
+fi
+
+# return to the directory where we called this script from
+cd -


### PR DESCRIPTION
This pull request does the following:
- update the bootstrapper script name to autogen.sh (see commit 866cfd5 in the libvips' repo),
- extract the VIPS' updater to be able to update VIPS without the need of building it,
- gitignore the libvips source tree,
- extend the build scripts to be controllable by environment variables. Therefore we become able to install to almost any directories and controll the script execution in a continuous integration environment.