### PR TITLE
Extend GUI translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-04 21:54+0200\n"
-"PO-Revision-Date: 2016-09-05 06:52+0200\n"
+"POT-Creation-Date: 2016-09-06 18:13+0200\n"
+"PO-Revision-Date: 2016-09-06 18:19+0200\n"
 "Last-Translator: Sven Claussner <scl.gplus@gmail.com>\n"
 "Language-Team: German <LL@li.org>\n"
 "Language: de\n"
@@ -19,33 +19,48 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #: src/operations/brightness_contrast_par.hh:12
+#: src/operations/brightness_contrast_par.hh:14
 msgid "brightness contrast"
 msgstr "Helligkeit Kontrast"
-
-#: src/operations/image_reader.hh:71
-msgid "image layer"
-msgstr "Bildebene"
 
 #: src/operations/channel_mixer.hh:51
 msgid "channel mixer"
 msgstr "Kanalmixer"
 
-#: src/operations/hue_saturation.cc:72
-msgid "B-C-S-H adjustment"
-msgstr "Farb- und Tonwerteinstellungen"
+#: src/operations/gradient.hh:69 src/operations/gradient.cc:86
+msgid "gradient"
+msgstr "Verlauf"
 
-#: src/operations/icc_transform.cc:42
-msgid "ICC transform"
+#: src/operations/image_reader.hh:71
+msgid "image layer"
+msgstr "Bildebene"
+
+#: src/operations/clone.cc:63
+msgid "layer clone"
+msgstr "Geklonte Ebene"
+
+#: src/operations/clone_stamp.cc:46
+msgid "clone stamp"
+msgstr "Klonpinsel"
+
+#: src/operations/convert_colorspace.cc:71
+#: src/operations/convert_colorspace.cc:72
+msgid "colorspace conversion"
 msgstr "Farbraumumwandlung"
 
-#: src/operations/impulse_nr.cc:52 src/gui/operations/denoise_config.cc:38
-msgid "impulse NR"
-msgstr "Impulsrauschen reduzieren"
+#: src/operations/crop.cc:46
+msgid "crop"
+msgstr "Freistellen"
+
+#: src/operations/curves.cc:75 src/operations/curves.cc:74
+msgid "curves"
+msgstr "Gradationskurve"
 
 # A non-standard word for lightness.
-#: src/operations/desaturate.cc:37
+#: src/operations/desaturate.cc:37 src/base/pftypes.cc:70
+#: src/base/pftypes.cc:79
 msgid "Luminosity"
-msgstr "Helligkeit"
+msgstr "Leuchtkraft"
 
 #: src/operations/desaturate.cc:39
 msgid "Lightness"
@@ -59,78 +74,643 @@ msgstr "Durchschnitt"
 msgid "Lab L channel"
 msgstr "Lab-L-Kanal"
 
-#: src/operations/desaturate.cc:51
+#: src/operations/desaturate.cc:50 src/operations/desaturate.cc:51
 msgid "desaturate"
 msgstr "Entsättigen"
 
-#: src/operations/path_mask.cc:209
-msgid "path mask"
-msgstr "Vektormaske"
+#: src/operations/draw.cc:67 src/operations/draw.cc:69
+#: src/gui/layerwidget.cc:152 src/gui/layerwidget.cc:151
+msgid "freehand drawing"
+msgstr "Freihandzeichnung"
+
+#: src/operations/gaussblur.cc:50
+msgid "gaussian blur"
+msgstr "Gauß'scher Weichzeichner"
+
+#: src/operations/hsl_mask.cc:47 src/operations/hsl_mask.cc:48
+msgid "HSL mask"
+msgstr "HSL-Maske"
+
+#: src/operations/hue_saturation.cc:71 src/operations/hue_saturation.cc:73
+msgid "B-C-S-H adjustment"
+msgstr "Farb- und Tonwerteinstellungen"
+
+#: src/operations/invert.cc:38 src/gui/operations/path_mask_config.cc:47
+#: src/gui/operations/threshold_config.cc:38
+msgid "invert"
+msgstr "Invertieren"
+
+#: src/operations/lensfun.cc:49 src/operations/lensfun.cc:62
+msgid "optical corrections"
+msgstr "Optische Korrekturen"
+
+#: src/operations/raw_developer.cc:68 src/gui/operationstree.cc:299
+#: src/operations/raw_developer.cc:85 src/gui/operationstree.cc:297
+msgid "RAW developer"
+msgstr "RAW-Entwickler"
+
+#: src/operations/scale.cc:61 src/operations/scale.cc:224
+msgid "scale and rotate"
+msgstr "Skalieren und rotieren"
 
 #: src/operations/sharpen.cc:59
 msgid "sharpening"
 msgstr "Schärfen"
 
-#: src/operations/raw_developer.cc:75 src/gui/operationstree.cc:297
-msgid "RAW developer"
-msgstr "RAW-Entwickler"
+#: src/operations/uniform.cc:49 src/gui/layerwidget.cc:148
+#: src/gui/layerwidget.cc:147
+msgid "uniform fill"
+msgstr "Füllung"
 
-#: src/operations/invert.cc:38 src/gui/operations/threshold_config.cc:38
-#: src/gui/operations/path_mask_config.cc:47
-msgid "invert"
-msgstr "Invertieren"
+#: src/operations/volume.cc:74
+msgid "local contrast"
+msgstr "Lokaler Kontrast"
 
-#: src/operations/convert_colorspace.cc:71
-msgid "colorspace conversion"
-msgstr "Farbraumumwandlung"
+#: src/gui/imageeditor.hh:164 src/gui/imageeditor.hh:184
+msgid "ready"
+msgstr "Bereit"
 
-#: src/operations/lensfun.cc:62
-msgid "optical corrections"
-msgstr "Optische Korrekturen"
+#: src/gui/imageeditor.hh:165 src/gui/imageeditor.hh:185
+msgid "caching"
+msgstr "Zwischenspeichern"
 
-#: src/operations/scale.cc:224
-msgid "scale and rotate"
-msgstr "Skalieren und rotieren"
+#: src/gui/imageeditor.hh:166 src/gui/imageeditor.hh:186
+msgid "processing"
+msgstr "Verarbeite"
 
-#: src/operations/draw.cc:68 src/gui/layerwidget.cc:149
-msgid "freehand drawing"
-msgstr "Freihandzeichnung"
+#: src/gui/imageeditor.hh:167 src/gui/imageeditor.hh:188
+msgid "exporting"
+msgstr "Exportiere"
 
-#: src/operations/clone.cc:63
-msgid "layer clone"
-msgstr "Geklonte Ebene"
+#: src/gui/imageeditor.cc:138 src/gui/imageeditor.cc:141
+#: src/gui/imageeditor.cc:142
+msgid "show merged layers"
+msgstr "Vereinte Ebenen anzeigen"
 
-#: src/operations/hsl_mask.cc:48
-msgid "HSL mask"
+#: src/gui/imageeditor.cc:139 src/gui/imageeditor.cc:142
+#: src/gui/imageeditor.cc:143
+msgid "show active layer"
+msgstr "Aktive Ebene anzeigen"
+
+#: src/gui/imageeditor.cc:424 src/gui/imageeditor.cc:481
+#: src/gui/imageeditor.cc:485
+#, c-format
+msgid "Crash recovery found for file \"%s\". Do you want to restore it?"
+msgstr ""
+"Wiederherstellbare Datei \"%s\" gefunden. Möchten Sie sie wiederherstellen?"
+
+#: src/gui/layerwidget.cc:101
+msgid "Load"
+msgstr "Laden"
+
+#: src/gui/layerwidget.cc:102 src/gui/mainwindow.cc:57
+msgid "Save"
+msgstr "Speichern"
+
+#: src/gui/layerwidget.cc:115 src/gui/layerwidget.cc:181
+#: src/gui/layerwidget.cc:180
+msgid "Layers"
+msgstr "Ebenen"
+
+#: src/gui/layerwidget.cc:123 src/gui/layerwidget.cc:192
+#: src/gui/layerwidget.cc:191
+msgid "Add a new layer"
+msgstr "Neue Ebene hinzufügen"
+
+#: src/gui/layerwidget.cc:125 src/gui/layerwidget.cc:194
+#: src/gui/layerwidget.cc:193
+msgid "Add a new layer group"
+msgstr "Neue Ebenengruppe hinzufügen"
+
+#: src/gui/layerwidget.cc:127 src/gui/layerwidget.cc:196
+#: src/gui/layerwidget.cc:195
+msgid "Remove selected layers"
+msgstr "Ausgewählte Ebenen entfernen"
+
+#: src/gui/layerwidget.cc:129 src/gui/layerwidget.cc:198
+#: src/gui/layerwidget.cc:197
+msgid "Load an existing preset"
+msgstr "Ein Preset laden"
+
+#: src/gui/layerwidget.cc:130 src/gui/layerwidget.cc:200
+#: src/gui/layerwidget.cc:199
+msgid "Save the selected layers as a preset"
+msgstr "Die ausgewählten Ebenen als Preset speichern"
+
+#: src/gui/layerwidget.cc:861 src/gui/layerwidget.cc:1250
+#: src/gui/layerwidget.cc:1249
+msgid "New Group Layer"
+msgstr "Neue Ebenengruppe"
+
+#: src/gui/layerwidget.cc:871 src/gui/layerwidget.cc:986
+#: src/gui/layerwidget.cc:1260 src/gui/layerwidget.cc:985
+#: src/gui/layerwidget.cc:1259
+msgid "Group Layer Config"
+msgstr "Ebenengruppenkonfiguration"
+
+#: src/gui/layerwidget.cc:901 src/gui/layerwidget.cc:906
+#: src/gui/layerwidget.cc:969 src/gui/layerwidget.cc:974
+#: src/gui/layerwidget.cc:1290 src/gui/layerwidget.cc:1295
+#: src/gui/layerwidget.cc:1362 src/gui/layerwidget.cc:1367
+#: src/gui/layerwidget.cc:1289 src/gui/layerwidget.cc:1294
+#: src/gui/layerwidget.cc:1361 src/gui/layerwidget.cc:1366
+msgid "Photoflow presets"
+msgstr "Photoflow-Presets"
+
+#: src/gui/layerwidget.cc:959 src/gui/layerwidget.cc:1352
+#: src/gui/layerwidget.cc:1351
+msgid "Save preset as..."
+msgstr "Preset speichern unter..."
+
+#: src/gui/mainwindow.cc:56
+msgid "Open"
+msgstr "Öffnen"
+
+#: src/gui/mainwindow.cc:58
+msgid "Save as"
+msgstr "Speichern unter"
+
+#: src/gui/mainwindow.cc:59 src/gui/mainwindow.cc:266
+msgid "Export"
+msgstr "Exportieren"
+
+#: src/gui/mainwindow.cc:60
+msgid "Exit"
+msgstr "Beenden"
+
+#: src/gui/mainwindow.cc:359 src/gui/operationstree.cc:295
+#: src/gui/layerwidget.cc:683 src/gui/mainwindow.cc:552
+#: src/gui/layerwidget.cc:682
+msgid "Open image"
+msgstr "Bild öffnen"
+
+#: src/gui/mainwindow.cc:374 src/gui/mainwindow.cc:385
+#: src/gui/layerwidget.cc:706 src/gui/layerwidget.cc:765
+#: src/gui/mainwindow.cc:567 src/gui/mainwindow.cc:625
+#: src/gui/layerwidget.cc:705 src/gui/layerwidget.cc:764
+msgid "Image files"
+msgstr "Bilddateien"
+
+#: src/gui/mainwindow.cc:380 src/gui/mainwindow.cc:391
+#: src/gui/layerwidget.cc:760 src/gui/layerwidget.cc:819
+#: src/gui/mainwindow.cc:620 src/gui/mainwindow.cc:678
+#: src/gui/layerwidget.cc:759 src/gui/layerwidget.cc:818
+msgid "All files"
+msgstr "Alle Dateien"
+
+#: src/gui/mainwindow.cc:463 src/gui/mainwindow.cc:752
+msgid "Save image as..."
+msgstr "Bild speichern unter..."
+
+#: src/gui/mainwindow.cc:479 src/gui/mainwindow.cc:484
+#: src/gui/mainwindow.cc:768 src/gui/mainwindow.cc:773
+msgid "Photoflow files"
+msgstr "Photoflow-Dateien"
+
+#: src/gui/mainwindow.cc:566 src/gui/mainwindow.cc:858
+msgid "Export image as..."
+msgstr "Bild exportieren als..."
+
+#: src/gui/mainwindow.cc:576 src/gui/mainwindow.cc:581
+#: src/gui/mainwindow.cc:880 src/gui/mainwindow.cc:885
+msgid "TIFF files"
+msgstr "TIFF-Dateien"
+
+#: src/gui/mainwindow.cc:588 src/gui/mainwindow.cc:593
+#: src/gui/mainwindow.cc:868 src/gui/mainwindow.cc:873
+msgid "JPEG files"
+msgstr "JPEG-Dateien"
+
+#: src/gui/mainwindow.cc:663 src/gui/mainwindow.cc:988
+#, c-format
+msgid ""
+"Image \"%s\" contains unsaved data. Do you want to save it before closing?"
+msgstr ""
+"Das Bild \"%s\" enthält ungesicherte Änderungen. Möchten Sie diese vor dem "
+"Beenden speichern?"
+
+#: src/gui/operation_config_gui.cc:79 src/gui/operation_config_gui.cc:80
+#: src/gui/operation_config_gui.cc:86 src/gui/operation_config_gui.cc:87
+#: src/gui/operation_config_gui.cc:88
+msgid "Intensity"
+msgstr "Effektstärke"
+
+#: src/gui/operation_config_gui.cc:81 src/gui/operation_config_gui.cc:82
+#: src/gui/operation_config_gui.cc:88 src/gui/operation_config_gui.cc:89
+#: src/gui/operation_config_gui.cc:90
+msgid "Opacity"
+msgstr "Deckkraft"
+
+#: src/gui/operation_config_gui.cc:83 src/gui/operation_config_gui.cc:84
+#: src/gui/operation_config_gui.cc:90 src/gui/operation_config_gui.cc:91
+#: src/gui/operation_config_gui.cc:92
+msgid "Enable mask"
+msgstr "Maske aktivieren"
+
+#: src/gui/operation_config_gui.cc:85
+msgid "X shift"
+msgstr "X-Offset"
+
+#: src/gui/operation_config_gui.cc:86
+msgid "Y shift"
+msgstr "Y-Offset"
+
+#: src/gui/operation_config_gui.cc:88 src/gui/operation_config_gui.cc:89
+#: src/gui/operation_config_gui.cc:90 src/gui/operation_config_gui.cc:95
+#: src/gui/operation_config_gui.cc:96 src/gui/operation_config_gui.cc:97
+#: src/gui/operation_config_gui.cc:98
+msgid "Target channel: "
+msgstr "Ziel-Kanal: "
+
+#: src/gui/operation_config_gui.cc:91 src/gui/operation_config_gui.cc:98
+#: src/gui/operation_config_gui.cc:99
+msgid "Target channel:"
+msgstr "Ziel-Kanal:"
+
+#: src/gui/operation_config_gui.cc:92 src/gui/operation_config_gui.cc:99
+#: src/gui/operation_config_gui.cc:100
+msgid "preview"
+msgstr "Vorschau"
+
+#: src/gui/operations/curves_config.cc:50
+#: src/gui/operations/curves_config.cc:63
+#: src/gui/operations/curves_config.cc:56
+#: src/gui/operations/curves_config.cc:75
+#: src/gui/operations/gradient_config.cc:68
+#: src/gui/operations/gradient_config.cc:81
+msgid "RGB"
+msgstr "RGB"
+
+#: src/gui/operations/curves_config.cc:51
+#: src/gui/operations/curves_config.cc:64
+#: src/gui/operations/curves_config.cc:57
+#: src/gui/operations/curves_config.cc:76
+#: src/gui/operations/gradient_config.cc:69
+#: src/gui/operations/gradient_config.cc:82
+msgid "Red"
+msgstr "Rot"
+
+#: src/gui/operations/curves_config.cc:52
+#: src/gui/operations/curves_config.cc:65
+#: src/gui/operations/curves_config.cc:58
+#: src/gui/operations/curves_config.cc:77
+#: src/gui/operations/gradient_config.cc:70
+#: src/gui/operations/gradient_config.cc:83
+msgid "Green"
+msgstr "Grün"
+
+#: src/gui/operations/curves_config.cc:53
+#: src/gui/operations/curves_config.cc:66
+#: src/gui/operations/curves_config.cc:59
+#: src/gui/operations/curves_config.cc:78
+#: src/gui/operations/gradient_config.cc:71
+#: src/gui/operations/gradient_config.cc:84
+msgid "Blue"
+msgstr "Blau"
+
+#: src/gui/operations/hsl_mask_config.cc:84
+#: src/gui/operations/hsl_mask_config.cc:86
+msgid "HSL Mask"
 msgstr "HSL-Maske"
 
-#: src/operations/perspective.cc:51 src/gui/layerwidget.cc:151
-msgid "perspective correction"
-msgstr "Perspektivkorrektur"
+#: src/gui/operations/hsl_mask_config.cc:91
+#: src/gui/operations/hsl_mask_config.cc:94
+msgid "Layer name:"
+msgstr "Ebenenname"
 
-#: src/operations/denoise.cc:52
-msgid "noise reduction"
+#: src/gui/operations/hue_saturation_config.cc:85
+#: src/gui/operations/hue_saturation_config.cc:87
+#: src/gui/operations/brightness_contrast_config.cc:41
+msgid "Brightness"
+msgstr "Helligkeit"
+
+#: src/gui/operations/hue_saturation_config.cc:87
+#: src/gui/operations/hue_saturation_config.cc:89
+#: src/gui/operations/brightness_contrast_config.cc:42
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: src/gui/operations/hue_saturation_config.cc:89
+#: src/gui/operations/hue_saturation_config.cc:91
+msgid "Saturation"
+msgstr "Sättigung"
+
+#: src/gui/operations/hue_saturation_config.cc:91
+#: src/gui/operations/hue_saturation_config.cc:93
+msgid "Hue"
+msgstr "Farbton"
+
+#: src/gui/operations/hue_saturation_config.cc:93
+#: src/gui/operations/hue_saturation_config.cc:96
+msgid "show mask"
+msgstr "Maske anzeigen"
+
+#: src/gui/operations/hue_saturation_config.cc:97
+#: src/gui/operations/hue_saturation_config.cc:98
+#: src/gui/operations/hue_saturation_config.cc:99
+#: src/gui/operations/hue_saturation_config.cc:100
+#: src/gui/operations/hue_saturation_config.cc:101
+#: src/gui/operations/hue_saturation_config.cc:102
+msgid "Enable"
+msgstr "Aktivieren"
+
+#: src/gui/operations/hue_saturation_config.cc:106
+msgid "feather mask"
+msgstr "Weiche Kante"
+
+#: src/gui/operations/hue_saturation_config.cc:107
+msgid "feather radius"
+msgstr "Ausblenderadius"
+
+#: src/gui/operations/hue_saturation_config.cc:122
+#: src/gui/operations/hue_saturation_config.cc:127
+msgid "H curve"
+msgstr "H-Kurve"
+
+#: src/gui/operations/hue_saturation_config.cc:123
+#: src/gui/operations/hue_saturation_config.cc:128
+msgid "S curve"
+msgstr "S-Kurve"
+
+#: src/gui/operations/hue_saturation_config.cc:124
+#: src/gui/operations/hue_saturation_config.cc:129
+msgid "L curve"
+msgstr "L-Kurve"
+
+#: src/gui/operations/hue_saturation_config.cc:140
+#: src/gui/operations/hue_saturation_config.cc:145
+msgid "HSL curves"
+msgstr "HSL-Kurven"
+
+#: src/gui/operationstree.cc:246
+msgid "Add New Layer"
+msgstr "Neue Ebene hinzufügen"
+
+#: src/gui/operationstree.cc:252 src/gui/settingsdialog.cc:61
+msgid "OK"
+msgstr "OK"
+
+#: src/gui/operationstree.cc:253 src/gui/settingsdialog.cc:62
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: src/gui/operationstree.cc:296
+msgid "Open RAW image"
+msgstr "RAW-Datei öffnen"
+
+#: src/gui/operationstree.cc:304 src/gui/operationstree.cc:302
+msgid "Color profile conversion"
+msgstr "Farbprofilumwandlung"
+
+#: src/gui/operationstree.cc:305
+msgid "B/C/S/H Adjustment"
+msgstr "Farb- und Tonwerteinstellungen"
+
+#: src/gui/operationstree.cc:306 src/gui/operationstree.cc:361
+#: src/gui/operationstree.cc:304 src/gui/operationstree.cc:371
+msgid "Curves"
+msgstr "Kurven"
+
+#: src/gui/operationstree.cc:307 src/gui/operationstree.cc:362
+#: src/gui/operationstree.cc:369 src/gui/operations/gradient_config.cc:48
+msgid "Invert"
+msgstr "Invertieren"
+
+#: src/gui/operationstree.cc:308
+msgid "Desaturate"
+msgstr "Entsättigen"
+
+#: src/gui/operationstree.cc:310 src/gui/operationstree.cc:311
+msgid "Channel Mixer"
+msgstr "Kanalmixer"
+
+#: src/gui/operationstree.cc:311 src/gui/operationstree.cc:363
+#: src/gui/operationstree.cc:312 src/gui/operationstree.cc:368
+msgid "Uniform Fill"
+msgstr "Füllung"
+
+#: src/gui/operationstree.cc:312 src/gui/operationstree.cc:364
+#: src/gui/operationstree.cc:313 src/gui/operationstree.cc:372
+msgid "Gradient"
+msgstr "Verlauf"
+
+#: src/gui/operationstree.cc:313 src/gui/operationstree.cc:365
+#: src/gui/operationstree.cc:314 src/gui/operationstree.cc:374
+msgid "H/S/L Mask"
+msgstr "H/S/L-Maske"
+
+#: src/gui/operationstree.cc:314 src/gui/operationstree.cc:315
+msgid "Emulate film [color slide]"
+msgstr "Farbfilm emulieren"
+
+#: src/gui/operationstree.cc:315 src/gui/operationstree.cc:316
+msgid "Emulate film [B&W]"
+msgstr "Schwarzweißfilm emulieren"
+
+#: src/gui/operationstree.cc:316 src/gui/operationstree.cc:317
+msgid "Emulate film [instant consumer]"
+msgstr "Consumer-Sofortbildfilm emulieren"
+
+#: src/gui/operationstree.cc:317 src/gui/operationstree.cc:318
+msgid "Emulate film [instant pro]"
+msgstr "Professionellen Sofortbildfilm emulieren"
+
+#: src/gui/operationstree.cc:318 src/gui/operationstree.cc:319
+msgid "Emulate film [negative color]"
+msgstr "Farbnegativfilm emulieren"
+
+#: src/gui/operationstree.cc:319 src/gui/operationstree.cc:320
+msgid "Emulate film [negative new]"
+msgstr "Negativfilm (neueres Modell) emulieren"
+
+#: src/gui/operationstree.cc:320 src/gui/operationstree.cc:321
+msgid "Emulate film [negative old]"
+msgstr "Negativfilm (älteres Modell) emulieren"
+
+#: src/gui/operationstree.cc:321 src/gui/operationstree.cc:322
+msgid "Emulate film [print films]"
+msgstr "Printfilm emulieren"
+
+#: src/gui/operationstree.cc:322 src/gui/operationstree.cc:323
+msgid "Emulate film [various]"
+msgstr "Verschiedene Filme emulieren"
+
+#: src/gui/operationstree.cc:324 src/gui/operationstree.cc:366
+#: src/gui/operationstree.cc:325 src/gui/operationstree.cc:375
+msgid "Gaussian blur"
+msgstr "Gauß'scher Weichzeichner"
+
+#: src/gui/operationstree.cc:325 src/gui/operationstree.cc:326
+msgid "Local contrast"
+msgstr "Lokaler Kontrast"
+
+#: src/gui/operationstree.cc:326 src/gui/operationstree.cc:327
+msgid "Sharpen"
+msgstr "Schärfen"
+
+#: src/gui/operationstree.cc:327 src/gui/operationstree.cc:339
+#: src/gui/operationstree.cc:370 src/gui/operationstree.cc:328
+#: src/gui/operationstree.cc:344 src/gui/operationstree.cc:379
+msgid "Gradient Norm"
+msgstr "Gradient Norm"
+
+#: src/gui/operationstree.cc:328
+msgid "Multi-level decomposition"
+msgstr "Bild zerlegen"
+
+#: src/gui/operationstree.cc:329 src/gui/operationstree.cc:331
+msgid "Noise reduction"
 msgstr "Rauschreduzierung"
 
-#: src/operations/uniform.cc:49 src/gui/layerwidget.cc:145
-msgid "uniform fill"
-msgstr "Gleichmäßige Füllung"
+#: src/gui/operationstree.cc:331 src/gui/operationstree.cc:333
+msgid "Crop image"
+msgstr "Bild beschneiden"
 
-#: src/operations/clone_stamp.cc:46
-msgid "clone stamp"
-msgstr "Klonpinsel"
+#: src/gui/operationstree.cc:332 src/gui/operationstree.cc:334
+msgid "Scale & rotate image"
+msgstr "Bild skalieren und rotieren"
 
-#: src/operations/raw_output.cc:57
-msgid "clip"
-msgstr "Abschneiden"
+#: src/gui/operationstree.cc:333 src/gui/operationstree.cc:337
+msgid "Optical corrections (experimental)"
+msgstr "Optische Korrekturen (experimentell)"
 
-#: src/operations/raw_output.cc:75
-msgid "blend"
-msgstr "Überblenden"
+#: src/gui/operationstree.cc:338 src/gui/operationstree.cc:343
+msgid "Dream Smoothing"
+msgstr "Träumerische Weichzeichnung"
 
-#: src/operations/raw_output.cc:76
-msgid "none"
-msgstr "Keine(r)"
+#: src/gui/operationstree.cc:340
+msgid "Convolve"
+msgstr "falten"
+
+#: src/gui/operationstree.cc:341
+msgid "Extract Foreground"
+msgstr "Vordergrund freistellen"
+
+#: src/gui/operationstree.cc:342
+msgid "Inpaint [patch-based]"
+msgstr "Inhaltsbasiert füllen (Patch-basiert)"
+
+#: src/gui/operationstree.cc:343
+msgid "Despeckle"
+msgstr "Entstören"
+
+#: src/gui/operationstree.cc:344
+msgid "Iain's Noise Reduction"
+msgstr "Rauschreduzierung (Iain)"
+
+#: src/gui/operationstree.cc:345 src/gui/operationstree.cc:350
+msgid "Sharpen [richardson-lucy]"
+msgstr "Schärfen (Richardson-Lucy-Algorithmus)"
+
+#: src/gui/operationstree.cc:346 src/gui/operationstree.cc:353
+msgid "Smooth [anisotropic]"
+msgstr "Weichzeichnen (anisotropisch)"
+
+#: src/gui/operationstree.cc:347 src/gui/operationstree.cc:354
+msgid "Smooth [bilateral]"
+msgstr "Weichzeichnen (bilateral)"
+
+#: src/gui/operationstree.cc:348 src/gui/operationstree.cc:355
+msgid "Smooth [diffusion]"
+msgstr "Weichzeichnen (Diffusion)"
+
+#: src/gui/operationstree.cc:349 src/gui/operationstree.cc:356
+msgid "Smooth [mean-curvature]"
+msgstr "Weichzeichnen (Durchschnitt)"
+
+#: src/gui/operationstree.cc:350 src/gui/operationstree.cc:357
+msgid "Smooth [median]"
+msgstr "Weichzeichnen (Median)"
+
+#: src/gui/operationstree.cc:351 src/gui/operationstree.cc:358
+msgid "Smooth [patch-based]"
+msgstr "Weichzeichnen (patch-basiert)"
+
+#: src/gui/operationstree.cc:352 src/gui/operationstree.cc:359
+msgid "Smooth [selective gaussian]"
+msgstr "Weichzeichnen (selektiv)"
+
+#: src/gui/operationstree.cc:353 src/gui/operationstree.cc:360
+msgid "Smooth [total variation]"
+msgstr "Weichzeichnen (total variation)"
+
+#: src/gui/operationstree.cc:354 src/gui/operationstree.cc:361
+msgid "Smooth [wavelets]"
+msgstr "Weichzeichnen (wavelet-basiert)"
+
+#: src/gui/operationstree.cc:355 src/gui/operationstree.cc:362
+msgid "Smooth [guided]"
+msgstr "Weichzeichnen (geführt)"
+
+#: src/gui/operationstree.cc:356 src/gui/operationstree.cc:363
+msgid "Tone mapping"
+msgstr "Tonemapping"
+
+#: src/gui/operationstree.cc:357 src/gui/operationstree.cc:364
+msgid "Transfer colors [advanced]"
+msgstr "Farben übertragen (fortgeschritten)"
+
+#: src/gui/operationstree.cc:372 src/gui/operationstree.cc:377
+#: src/gui/operationstree.cc:381 src/gui/operationstree.cc:386
+msgid "Draw"
+msgstr "Zeichnen"
+
+#: src/gui/operationstree.cc:373 src/gui/operationstree.cc:379
+#: src/gui/operationstree.cc:382 src/gui/operationstree.cc:388
+msgid "Clone layer"
+msgstr "Ebene klonen"
+
+#: src/gui/operationstree.cc:378 src/gui/operationstree.cc:387
+msgid "Clone stamp"
+msgstr "Klonstempel"
+
+#: src/gui/operationstree.cc:380 src/gui/operationstree.cc:389
+msgid "Buffer layer"
+msgstr "Zwischenspeicher"
+
+#: src/gui/operationstree.cc:381 src/gui/operationstree.cc:390
+msgid "Digital watermark"
+msgstr "Digitales Wasserzeichen"
+
+#: src/gui/operationstree.cc:501 src/gui/operationstree.cc:510
+#: src/gui/widgets/toolbutton.cc:103
+msgid "New Layer"
+msgstr "Neue Ebene"
+
+#: src/operations/split_details.cc:173
+msgid "gaussian"
+msgstr "Gauß'scher Weichzeichner"
+
+#: src/operations/split_details.cc:177
+msgid "wavelets"
+msgstr "Wavelets"
+
+#: src/operations/split_details.cc:180
+msgid "split details"
+msgstr "Details extrahieren"
+
+#: src/operations/subtr_image.cc:45
+msgid "Subtract Image"
+msgstr "Bild subtrahieren"
+
+#: src/operations/threshold.cc:39 src/gui/operations/defringe_config.cc:47
+#: src/gui/operations/denoise_config.cc:39
+#: src/gui/operations/raw_developer_config.cc:351
+#: src/gui/operations/threshold_config.cc:37
+msgid "threshold"
+msgstr "Schwellwert"
+
+#: src/operations/wavdec.cc:49
+msgid "Wavelet Decompose"
+msgstr "Wavelet-Zerlegung"
+
+#: src/operations/defringe.cc:57
+msgid "defringe"
+msgstr "Farbsaum entfernen"
+
+#: src/operations/denoise.cc:59
+msgid "noise reduction"
+msgstr "Rauschreduzierung"
 
 #: src/operations/gradient.cc:36
 msgid "Vertical"
@@ -144,172 +724,347 @@ msgstr "horizontal"
 msgid "Radial"
 msgstr "radial"
 
-#: src/operations/gradient.cc:86
-msgid "gradient"
-msgstr "Verlauf"
+#: src/operations/icc_transform.cc:42
+msgid "ICC transform"
+msgstr "Farbraumumwandlung"
 
-#: src/operations/crop.cc:46
-msgid "crop"
-msgstr "Beschneiden"
+#: src/operations/impulse_nr.cc:50 src/gui/operations/denoise_config.cc:38
+msgid "impulse NR"
+msgstr "Impulsrauschen reduzieren"
 
-#: src/operations/volume.cc:74
-msgid "local contrast"
-msgstr "Lokaler Kontrast"
+#: src/operations/nlmeans.cc:50
+msgid "NL means"
+msgstr "Nicht-lokales Mittel"
 
-#: src/operations/threshold.cc:39 src/gui/operations/denoise_config.cc:39
-#: src/gui/operations/threshold_config.cc:37
-msgid "threshold"
-msgstr "Schwellwert"
+#: src/operations/path_mask.cc:209
+msgid "path mask"
+msgstr "Vektormaske"
 
-#: src/operations/gaussblur.cc:50
-msgid "gaussian blur"
-msgstr "Gauß'scher Weichzeichner"
+#: src/operations/perspective.cc:51 src/gui/layerwidget.cc:154
+#: src/gui/layerwidget.cc:153
+msgid "perspective correction"
+msgstr "Perspektivkorrektur"
 
-#: src/operations/curves.cc:74
-msgid "curves"
-msgstr "Gradationskurve"
+#: src/operations/raw_output.cc:57
+msgid "clip"
+msgstr "Abschneiden"
 
-#: src/gui/imageeditor.hh:177
-msgid "ready"
-msgstr "Bereit"
+#: src/operations/raw_output.cc:75
+msgid "blend"
+msgstr "Überblenden"
 
-#: src/gui/imageeditor.hh:178
-msgid "caching"
-msgstr "Zwischenspeichern"
+#: src/operations/raw_output.cc:76
+msgid "none"
+msgstr "Keine(r)"
 
-#: src/gui/imageeditor.hh:179
-msgid "processing"
-msgstr "Verarbeite"
+#: src/operations/shadows_highlights.cc:60
+msgid "shadows/highlights"
+msgstr "Schatten/Spitzlichter"
 
-#: src/gui/imageeditor.hh:180
-msgid "exporting"
-msgstr "Exportiere"
+#: src/gui/imageeditor.hh:187
+msgid "updating"
+msgstr "Aktualisiere"
 
-#: src/gui/imageeditor.cc:144
-msgid "show merged layers"
-msgstr "Vereinte Ebenen anzeigen"
-
-#: src/gui/imageeditor.cc:145
-msgid "show active layer"
-msgstr "Aktive Ebene anzeigen"
-
-#: src/gui/imageeditor.cc:193
+#: src/gui/imageeditor.cc:191 src/gui/imageeditor.cc:192
 msgid "Toggle highlights clipping warning on/off"
-msgstr "Lichterwarnung an/aus"
+msgstr "Spitzlichtwarnung an/aus"
 
-#: src/gui/imageeditor.cc:197
+#: src/gui/imageeditor.cc:195 src/gui/imageeditor.cc:196
 msgid "Toggle shadows clipping warning on/off"
-msgstr "Tiefenwarnung an/aus"
+msgstr "Schattenwarnung an/aus"
 
-#: src/gui/imageeditor.cc:203
+#: src/gui/imageeditor.cc:201 src/gui/imageeditor.cc:202
 msgid "Zoom to 100%"
 msgstr "Auf 100% zoomen"
 
-#: src/gui/imageeditor.cc:207
+#: src/gui/imageeditor.cc:205 src/gui/imageeditor.cc:206
 msgid "Fit image to preview area"
 msgstr "Bild in Ansicht einpassen"
 
-#: src/gui/imageeditor.cc:211
+#: src/gui/imageeditor.cc:209 src/gui/imageeditor.cc:210
 msgid "Zoom out"
 msgstr "Herauszoomen"
 
-#: src/gui/imageeditor.cc:215
+#: src/gui/imageeditor.cc:213 src/gui/imageeditor.cc:214
 msgid "Zoom in"
 msgstr "Hineinzoomen"
 
-#: src/gui/imageeditor.cc:224
+#: src/gui/imageeditor.cc:222 src/gui/imageeditor.cc:223
 msgid "histogram"
 msgstr "Histogramm"
 
-#: src/gui/imageeditor.cc:481
-#, c-format
-msgid "Crash recovery found for file \"%s\". Do you want to restore it?"
-msgstr ""
-"Wiederherstellbare Datei \"%s\" gefunden. Möchten Sie sie wiederherstellen?"
+#: src/gui/layerwidget.cc:116 src/gui/mainwindow.cc:100
+#: src/gui/layerwidget.cc:115
+msgid "New Adjustment"
+msgstr "Neue Korrektur"
 
-#: src/gui/operations/hsl_mask_config.cc:86
-msgid "HSL Mask"
-msgstr "HSL-Maske"
+#: src/gui/layerwidget.cc:119 src/gui/layerwidget.cc:118
+msgid "Load preset"
+msgstr "Preset laden"
 
-#: src/gui/operations/hsl_mask_config.cc:94
-msgid "Layer name:"
-msgstr "Ebenenname"
+#: src/gui/layerwidget.cc:120 src/gui/layerwidget.cc:119
+msgid "Save preset"
+msgstr "Preset speichern"
 
-#: src/gui/operations/raw_developer_config.cc:333
+#: src/gui/layerwidget.cc:142 src/gui/layerwidget.cc:141
+msgid "new layer"
+msgstr "Neue Ebene"
+
+#: src/gui/layerwidget.cc:143 src/gui/layerwidget.cc:142
+msgid "new group layer"
+msgstr "Neue Ebenengruppe"
+
+#: src/gui/layerwidget.cc:144 src/gui/layerwidget.cc:143
+msgid "delete layer"
+msgstr "Ebene löschen"
+
+#: src/gui/layerwidget.cc:145 src/gui/layerwidget.cc:144
+msgid "insert image as layer"
+msgstr "Bild als neue Ebene einfügen"
+
+#: src/gui/layerwidget.cc:146 src/gui/layerwidget.cc:145
+msgid "basic editing"
+msgstr "Grundlegende Bearbeitung"
+
+#: src/gui/layerwidget.cc:147 src/gui/layerwidget.cc:146
+msgid "curves tool"
+msgstr "Gradationskurve"
+
+#: src/gui/layerwidget.cc:149 src/gui/layerwidget.cc:148
+msgid "gradient tool"
+msgstr "Verlaufswerkzeug"
+
+#: src/gui/layerwidget.cc:150 src/gui/layerwidget.cc:149
+msgid "desaturate tool"
+msgstr "Entsättigen"
+
+#: src/gui/layerwidget.cc:151 src/gui/layerwidget.cc:150
+msgid "crop tool"
+msgstr "Freistellungswerkzeug"
+
+#: src/gui/layerwidget.cc:153 src/gui/layerwidget.cc:152
+msgid "clone stamp tool"
+msgstr "Klonstempel"
+
+#: src/gui/layerwidget.cc:155 src/gui/layerwidget.cc:154
+msgid "scale/rotate tool"
+msgstr "Skalieren-und-rotieren-Werkzeug"
+
+#: src/gui/layerwidget.cc:156 src/gui/layerwidget.cc:155
+msgid "path tool"
+msgstr "Pfadwerkzeug"
+
+#: src/gui/layerwidget.cc:976 src/gui/layerwidget.cc:975
+msgid "RAW image"
+msgstr "RAW-Datei"
+
+#: src/gui/mainwindow.cc:79
+msgid "files"
+msgstr "Dateien"
+
+#: src/gui/mainwindow.cc:80
+msgid "editing"
+msgstr "Bearbeite"
+
+#: src/gui/mainwindow.cc:101
+msgid "New Group"
+msgstr "Neue Ebenengruppe"
+
+#: src/gui/mainwindow.cc:137 src/gui/mainwindow.cc:161
+#: src/gui/mainwindow.cc:164
+msgid "Open existing file"
+msgstr "Vorhandene Datei öffnen"
+
+#: src/gui/mainwindow.cc:139
+msgid "Save current image"
+msgstr "Bild speichern"
+
+#: src/gui/mainwindow.cc:141
+msgid "Save current image with a different name"
+msgstr "Bild unter anderem Namen speichern"
+
+#: src/gui/mainwindow.cc:143
+msgid "Export current image to raster format"
+msgstr "Aktuelles Bild in ein Rasterformat exportieren"
+
+#: src/gui/mainwindow.cc:145
+msgid "Open settings dialog"
+msgstr "Einstellungen-Dialog öffnen"
+
+#: src/gui/mainwindow.cc:147
+msgid "Exit PhotoFlow"
+msgstr "PhotoFlow beenden"
+
+#: src/gui/operation_config_gui.cc:92 src/gui/operation_config_gui.cc:93
+msgid "X shift "
+msgstr "X-Offset"
+
+#: src/gui/operation_config_gui.cc:93 src/gui/operation_config_gui.cc:94
+msgid "Y shift "
+msgstr "Y-Offset"
+
+#: src/gui/operation_config_gui.cc:253 src/gui/operation_config_gui.cc:254
+msgid "toggle layer visibility on/off"
+msgstr "Ebenen ein-/ausblenden"
+
+#: src/gui/operation_config_gui.cc:254 src/gui/operation_config_gui.cc:255
+#: src/gui/operation_config_gui.cc:256
+msgid "enable/disable layer mask(s)"
+msgstr "Ebenenmasken de-/aktivieren"
+
+#: src/gui/operation_config_gui.cc:256 src/gui/operation_config_gui.cc:257
+#: src/gui/operation_config_gui.cc:258
+msgid "toggle sticky flag on/off"
+msgstr "Voransicht nur für aktuelle Ebene anzeigen (an/aus)"
+
+#: src/gui/operation_config_gui.cc:258 src/gui/operation_config_gui.cc:259
+#: src/gui/operation_config_gui.cc:260
+msgid "toggle editing flag on/off"
+msgstr "Bearbeiten an/aus"
+
+#: src/gui/operation_config_gui.cc:260 src/gui/operation_config_gui.cc:261
+msgid "reset tool parameters"
+msgstr "Werkzeugeinstellungen zurücksetzen"
+
+#: src/gui/operation_config_gui.cc:261 src/gui/operation_config_gui.cc:262
+#: src/gui/operation_config_gui.cc:263
+msgid "show information on current tool"
+msgstr "Informationen zum aktuellen Werkzeug anzeigen"
+
+#: src/gui/operation_config_gui.cc:707 src/gui/operation_config_gui.cc:708
+msgid "Close"
+msgstr "Schließen"
+
+#: src/gui/operations/defringe_config.cc:41
+msgid "operation mode"
+msgstr "Arbeitsmodus"
+
+#: src/gui/operations/defringe_config.cc:44
+msgid "edge dection radius"
+msgstr "Radius der Kantenerkennung"
+
+#: src/gui/operations/denoise_config.cc:40
+msgid "non-local means"
+msgstr "Nicht-lokales Mittel"
+
+#: src/gui/operations/denoise_config.cc:41
+#: src/gui/operations/gmic/smooth_nlmeans_config.cc:38
+#: src/gui/operations/shadows_highlights_config.cc:39
+msgid "radius"
+msgstr "Radius"
+
+#: src/gui/operations/denoise_config.cc:42
+#: src/gui/operations/raw_developer_config.cc:352
+msgid "strength"
+msgstr "Stärke"
+
+#: src/gui/operations/denoise_config.cc:43
+msgid "luma"
+msgstr "Luma"
+
+#: src/gui/operations/denoise_config.cc:44
+msgid "chroma"
+msgstr "Farbigkeit"
+
+#: src/gui/operations/draw_config.cc:48
+msgid "transparent"
+msgstr "transparent"
+
+#: src/gui/operations/gmic/smooth_nlmeans_config.cc:39
+msgid "size"
+msgstr "Größe"
+
+#: src/gui/operations/hue_saturation_config.cc:95
+msgid "gamma"
+msgstr "Gamma"
+
+#: src/gui/operations/hue_saturation_config.cc:109
+msgid "feather"
+msgstr "Weiche Kante"
+
+#: src/gui/operations/hue_saturation_config.cc:110
+msgid "radius "
+msgstr "Radius"
+
+#: src/gui/operations/hue_saturation_config.cc:111
+msgid "invert mask"
+msgstr "Maske invertieren"
+
+#: src/gui/operations/imageread_config.cc:40
+msgid "file name:"
+msgstr "Dateiname:"
+
+#: src/gui/operations/path_mask_config.cc:48
+msgid "enable falloff"
+msgstr "Weiche Kante"
+
+#: src/gui/operations/raw_developer_config.cc:334
 msgid "temperature"
 msgstr "Farbtemperatur"
 
-#: src/gui/operations/raw_developer_config.cc:334
+#: src/gui/operations/raw_developer_config.cc:335
 msgid "tint"
 msgstr "Einfärben"
 
-#: src/gui/operations/raw_developer_config.cc:344
+#: src/gui/operations/raw_developer_config.cc:345
 msgid "enable CA correction"
 msgstr "Chromatische Abberation korrigieren"
 
-#: src/gui/operations/raw_developer_config.cc:345
+#: src/gui/operations/raw_developer_config.cc:346
 msgid "auto"
 msgstr "Auto"
 
-#: src/gui/operations/raw_developer_config.cc:346
+#: src/gui/operations/raw_developer_config.cc:347
 msgid "red"
 msgstr "rot"
 
-#: src/gui/operations/raw_developer_config.cc:347
+#: src/gui/operations/raw_developer_config.cc:348
 msgid "blue"
 msgstr "blau"
 
-#: src/gui/operations/raw_developer_config.cc:348
+#: src/gui/operations/raw_developer_config.cc:349
+msgid "CA correction"
+msgstr "Chromatische Aberration korrigieren"
+
+#: src/gui/operations/raw_developer_config.cc:350
+msgid "enable hot pixels correction"
+msgstr "Chromatische Abberation korrigieren"
+
+#: src/gui/operations/raw_developer_config.cc:353
+msgid "detect by 3 neighbors"
+msgstr "aus drei Nachbarpixeln ermitteln"
+
+#: src/gui/operations/raw_developer_config.cc:354
+msgid "mark fixed pixels"
+msgstr "Korrigierte Pixel hervorheben"
+
+#: src/gui/operations/raw_developer_config.cc:355
+msgid "hot pixels filter"
+msgstr "Hot-Pixels-Filter"
+
+#: src/gui/operations/raw_developer_config.cc:356
 msgid "method: "
 msgstr "Methode"
 
-#: src/gui/operations/raw_developer_config.cc:351
+#: src/gui/operations/raw_developer_config.cc:359
 msgid "RAW white level %"
 msgstr "RAW-Weißpunkt %"
 
-#: src/gui/operations/raw_developer_config.cc:352
+#: src/gui/operations/raw_developer_config.cc:360
 msgid "RAW black level %"
 msgstr "RAW-Schwarzpunkt %"
 
-#: src/gui/operations/raw_developer_config.cc:353
+#: src/gui/operations/raw_developer_config.cc:361
 msgid "highlights reco: "
-msgstr "Lichter restaurieren:"
+msgstr "Spitzlichter rekonstruieren:"
 
-#: src/gui/operations/raw_developer_config.cc:354
+#: src/gui/operations/raw_developer_config.cc:362
 msgid "input: "
 msgstr "Eingabe:"
 
-#: src/gui/operations/raw_developer_config.cc:359
+#: src/gui/operations/raw_developer_config.cc:367
 msgid "working profile: "
 msgstr "Arbeitsprofil"
-
-#: src/gui/operations/curves_config.cc:56
-#: src/gui/operations/curves_config.cc:75
-#: src/gui/operations/gradient_config.cc:68
-#: src/gui/operations/gradient_config.cc:81
-msgid "RGB"
-msgstr "RGB"
-
-#: src/gui/operations/curves_config.cc:57
-#: src/gui/operations/curves_config.cc:76
-#: src/gui/operations/gradient_config.cc:69
-#: src/gui/operations/gradient_config.cc:82
-msgid "Red"
-msgstr "Rot"
-
-#: src/gui/operations/curves_config.cc:58
-#: src/gui/operations/curves_config.cc:77
-#: src/gui/operations/gradient_config.cc:70
-#: src/gui/operations/gradient_config.cc:83
-msgid "Green"
-msgstr "Grün"
-
-#: src/gui/operations/curves_config.cc:59
-#: src/gui/operations/curves_config.cc:78
-#: src/gui/operations/gradient_config.cc:71
-#: src/gui/operations/gradient_config.cc:84
-msgid "Blue"
-msgstr "Blau"
 
 #: src/gui/operations/scale_config.cc:37
 msgid "flip vertically"
@@ -357,288 +1112,77 @@ msgstr "H:"
 msgid "resolution: "
 msgstr "Auflösung:"
 
-#: src/gui/operations/imageread_config.cc:40
-msgid "file name:"
-msgstr "Dateiname:"
+#: src/gui/operations/shadows_highlights_config.cc:35
+msgid "soften with: "
+msgstr "Weichzeichnen mit:"
 
-#: src/gui/operations/hue_saturation_config.cc:87
-msgid "Brightness"
-msgstr "Hellligkeit"
+#: src/gui/operations/shadows_highlights_config.cc:36
+msgid "shadows"
+msgstr "Schatten"
 
-#: src/gui/operations/hue_saturation_config.cc:89
-msgid "Contrast"
-msgstr "Kontrast"
+#: src/gui/operations/shadows_highlights_config.cc:37
+msgid "highlights"
+msgstr "Spitzlichter"
 
-#: src/gui/operations/hue_saturation_config.cc:91
-msgid "Saturation"
-msgstr "Sättigung"
+#: src/gui/operations/shadows_highlights_config.cc:38
+msgid "whithe point adjustment"
+msgstr "Weißpunkteinstellung"
 
-#: src/gui/operations/hue_saturation_config.cc:93
-msgid "Hue"
-msgstr "Farbton"
+#: src/gui/operations/shadows_highlights_config.cc:40
+msgid "compress"
+msgstr "komprimieren"
 
-#: src/gui/operations/hue_saturation_config.cc:95
-msgid "show mask"
-msgstr "Maske anzeigen"
+#: src/gui/operations/shadows_highlights_config.cc:41
+msgid "shadows color adjustment"
+msgstr "Schatten korrigieren"
 
-#: src/gui/operations/hue_saturation_config.cc:99
-#: src/gui/operations/hue_saturation_config.cc:100
-#: src/gui/operations/hue_saturation_config.cc:101
-msgid "Enable"
-msgstr "Aktivieren"
+#: src/gui/operations/shadows_highlights_config.cc:42
+msgid "highlights color adjustment"
+msgstr "Spitzlichter korrigieren"
 
-#: src/gui/operations/hue_saturation_config.cc:108
-msgid "feather"
-msgstr "Weiche Kante"
+#: src/gui/operations/split_details_config.cc:36
+msgid "blur type: "
+msgstr "Weichzeichnertyp:"
 
-#: src/gui/operations/hue_saturation_config.cc:109
-msgid "radius "
-msgstr "Radius"
+#: src/gui/operations/wavdec_config.cc:35
+msgid "Scales"
+msgstr "Skalierungen"
 
-#: src/gui/operations/hue_saturation_config.cc:110
-msgid "invert mask"
-msgstr "Maske invertieren"
+#: src/gui/operations/wavdec_config.cc:36
+msgid "Preview Scale"
+msgstr "Vorschaugröße"
 
-#: src/gui/operations/hue_saturation_config.cc:125
-msgid "H curve"
-msgstr "H-Kurve"
-
-#: src/gui/operations/hue_saturation_config.cc:126
-msgid "S curve"
-msgstr "S-Kurve"
-
-#: src/gui/operations/hue_saturation_config.cc:127
-msgid "L curve"
-msgstr "L-Kurve"
-
-#: src/gui/operations/hue_saturation_config.cc:143
-msgid "HSL curves"
-msgstr "HSL-Kurven"
-
-#: src/gui/operations/path_mask_config.cc:48
-msgid "enable falloff"
-msgstr "Weiche Kante"
-
-#: src/gui/operationstree.cc:246
-msgid "Add New Layer"
-msgstr "Neue Ebene hinzufügen"
-
-#: src/gui/operationstree.cc:252 src/gui/settingsdialog.cc:61
-msgid "OK"
-msgstr "OK"
-
-#: src/gui/operationstree.cc:253 src/gui/settingsdialog.cc:62
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: src/gui/operationstree.cc:295 src/gui/mainwindow.cc:552
-msgid "Open image"
-msgstr "Bild öffnen"
-
-#: src/gui/operationstree.cc:296
-msgid "Open RAW image"
-msgstr "RAW-Datei öffnen"
-
-#: src/gui/operationstree.cc:302
-msgid "Color profile conversion"
-msgstr "Farbprofilumwandlung"
+#: src/gui/operations/wavdec_config.cc:37
+msgid "Blend Factor"
+msgstr "Überblendungsfaktor"
 
 #: src/gui/operationstree.cc:303
 msgid "Basic Adjustments"
 msgstr "Grundlegende Korrekturen"
 
-#: src/gui/operationstree.cc:304 src/gui/operationstree.cc:364
-msgid "Curves"
-msgstr "Kurven"
-
-#: src/gui/operationstree.cc:305 src/gui/operationstree.cc:362
-msgid "Invert"
-msgstr "Invertieren"
+#: src/gui/operationstree.cc:305
+msgid "Shadows/Highlights"
+msgstr "Schatten/Spitzlichter"
 
 #: src/gui/operationstree.cc:306
-msgid "Desaturate"
-msgstr "Entsättigen"
+msgid "Defringe"
+msgstr "Farbsaumentfernung"
 
-#: src/gui/operationstree.cc:307 src/gui/operationstree.cc:363
+#: src/gui/operationstree.cc:309 src/gui/operationstree.cc:370
 msgid "Threshold"
 msgstr "Schwellwert"
 
-#: src/gui/operationstree.cc:309
-msgid "Channel Mixer"
-msgstr "Kanalmixer"
+#: src/gui/operationstree.cc:329
+msgid "Split Details"
+msgstr "Details extrahieren"
 
-#: src/gui/operationstree.cc:310 src/gui/operationstree.cc:361
-msgid "Uniform Fill"
-msgstr "Gleichmäßige Füllung"
-
-#: src/gui/operationstree.cc:311 src/gui/operationstree.cc:365
-msgid "Gradient"
-msgstr "Verlauf"
-
-#: src/gui/operationstree.cc:312 src/gui/operationstree.cc:367
-msgid "H/S/L Mask"
-msgstr "H/S/L-Maske"
-
-#: src/gui/operationstree.cc:313
-msgid "Emulate film [color slide]"
-msgstr "Farbfilm emulieren"
-
-#: src/gui/operationstree.cc:314
-msgid "Emulate film [B&W]"
-msgstr "Schwarzweißfilm emulieren"
-
-#: src/gui/operationstree.cc:315
-msgid "Emulate film [instant consumer]"
-msgstr "Consumer-Sofortbildfilm emulieren"
-
-#: src/gui/operationstree.cc:316
-msgid "Emulate film [instant pro]"
-msgstr "Professionellen Sofortbildfilm emulieren"
-
-#: src/gui/operationstree.cc:317
-msgid "Emulate film [negative color]"
-msgstr "Farbnegativfilm emulieren"
-
-#: src/gui/operationstree.cc:318
-msgid "Emulate film [negative new]"
-msgstr "Negativfilm (neueres Modell) emulieren"
-
-#: src/gui/operationstree.cc:319
-msgid "Emulate film [negative old]"
-msgstr "Negativfilm (älteres Modell) emulieren"
-
-#: src/gui/operationstree.cc:320
-msgid "Emulate film [print films]"
-msgstr "Printfilm emulieren"
-
-#: src/gui/operationstree.cc:321
-msgid "Emulate film [various]"
-msgstr "Verschiedene Filme emulieren"
-
-#: src/gui/operationstree.cc:323 src/gui/operationstree.cc:368
-msgid "Gaussian blur"
-msgstr "Gauß'scher Weichzeichner"
-
-#: src/gui/operationstree.cc:324
-msgid "Local contrast"
-msgstr "Lokaler Kontrast"
-
-#: src/gui/operationstree.cc:325
-msgid "Sharpen"
-msgstr "Schärfen"
-
-#: src/gui/operationstree.cc:326 src/gui/operationstree.cc:339
-#: src/gui/operationstree.cc:372
-msgid "Gradient Norm"
-msgstr ""
-
-#: src/gui/operationstree.cc:327
-msgid "Multi-level decomposition"
-msgstr "Bild zerlegen"
-
-#: src/gui/operationstree.cc:328
-msgid "Noise reduction"
-msgstr "Rauschreduzierung"
-
-#: src/gui/operationstree.cc:330
-msgid "Crop image"
-msgstr "Bild beschneiden"
-
-#: src/gui/operationstree.cc:331
-msgid "Scale & rotate image"
-msgstr "Bild skalieren und rotieren"
-
-#: src/gui/operationstree.cc:332
+#: src/gui/operationstree.cc:335
 msgid "Perspective correction"
 msgstr "Perspektivkorrektur"
 
-#: src/gui/operationstree.cc:333
-msgid "Optical corrections (experimental)"
-msgstr "Optische Korrekturen (experimentell)"
-
-#: src/gui/operationstree.cc:338
-msgid "Dream Smoothing"
-msgstr "Träumerische Weichzeichnung"
-
-#: src/gui/operationstree.cc:345
-msgid "Sharpen [richardson-lucy]"
-msgstr "Schärfen (Richardson-Lucy-Algorithmus)"
-
-#: src/gui/operationstree.cc:346
-msgid "Smooth [anisotropic]"
-msgstr "Weichzeichnen (anisotropisch)"
-
-#: src/gui/operationstree.cc:347
-msgid "Smooth [bilateral]"
-msgstr "Weichzeichnen (bilateral)"
-
-#: src/gui/operationstree.cc:348
-msgid "Smooth [diffusion]"
-msgstr "Weichzeichnen (Diffusion)"
-
-#: src/gui/operationstree.cc:349
-msgid "Smooth [mean-curvature]"
-msgstr "Weichzeichnen (Durchschnitt)"
-
-#: src/gui/operationstree.cc:350
-msgid "Smooth [median]"
-msgstr "Weichzeichnen (Median)"
-
-#: src/gui/operationstree.cc:351
-msgid "Smooth [patch-based]"
-msgstr "Weichzeichnen (Patch-basiert)"
-
-#: src/gui/operationstree.cc:352
-msgid "Smooth [selective gaussian]"
-msgstr "Weichzeichnen (selektiv)"
-
-#: src/gui/operationstree.cc:353
-msgid "Smooth [total variation]"
-msgstr "Weichzeichnen (total variation)"
-
-#: src/gui/operationstree.cc:354
-msgid "Smooth [wavelets]"
-msgstr "Weichzeichnen (wavelet-basiert)"
-
-#: src/gui/operationstree.cc:355
-msgid "Smooth [guided]"
-msgstr "Weichzeichnen (geführt)"
-
-#: src/gui/operationstree.cc:356
-msgid "Tone mapping"
-msgstr "Tonemapping"
-
-#: src/gui/operationstree.cc:357
-msgid "Transfer colors [advanced]"
-msgstr "Farben übertragen (fortgeschritten)"
-
-#: src/gui/operationstree.cc:366
+#: src/gui/operationstree.cc:373
 msgid "Path"
 msgstr "Pfad"
-
-#: src/gui/operationstree.cc:374 src/gui/operationstree.cc:379
-msgid "Draw"
-msgstr "Zeichnen"
-
-#: src/gui/operationstree.cc:375 src/gui/operationstree.cc:381
-msgid "Clone layer"
-msgstr "Ebene klonen"
-
-#: src/gui/operationstree.cc:380
-msgid "Clone stamp"
-msgstr "Klonstempel"
-
-#: src/gui/operationstree.cc:382
-msgid "Buffer layer"
-msgstr "Zwischenspeicher"
-
-#: src/gui/operationstree.cc:383
-msgid "Digital watermark"
-msgstr "Digitales Wasserzeichen"
-
-#: src/gui/operationstree.cc:503 src/gui/widgets/toolbutton.cc:103
-msgid "New Layer"
-msgstr "Neue Ebene"
 
 #: src/gui/settingsdialog.cc:56
 msgid "Settings"
@@ -652,266 +1196,242 @@ msgstr "Benutzerdefiniertes Bildschirmprofil: "
 msgid "display profile type: "
 msgstr "Bildschirmprofil: "
 
-#: src/gui/operation_config_gui.cc:82 src/gui/operation_config_gui.cc:83
-msgid "Intensity"
-msgstr "Intensität"
-
-#: src/gui/operation_config_gui.cc:84 src/gui/operation_config_gui.cc:85
-msgid "Opacity"
-msgstr "Deckkraft"
-
-#: src/gui/operation_config_gui.cc:86 src/gui/operation_config_gui.cc:87
-msgid "Enable mask"
-msgstr "Maske aktivieren"
-
-#: src/gui/operation_config_gui.cc:88
-msgid "X shift "
-msgstr "X-Offset"
-
-#: src/gui/operation_config_gui.cc:89
-msgid "Y shift "
-msgstr "Y-Offset"
-
-#: src/gui/operation_config_gui.cc:91 src/gui/operation_config_gui.cc:92
-#: src/gui/operation_config_gui.cc:93
-msgid "Target channel: "
-msgstr "Ziel-Kanal: "
-
-#: src/gui/operation_config_gui.cc:94
-msgid "Target channel:"
-msgstr "Ziel-Kanal:"
-
-#: src/gui/operation_config_gui.cc:95
-msgid "preview"
-msgstr "Vorschau"
-
-#: src/gui/operation_config_gui.cc:249
-msgid "toggle layer visibility on/off"
-msgstr "Ebenen ein-/ausblenden"
-
-#: src/gui/operation_config_gui.cc:250 src/gui/operation_config_gui.cc:251
-msgid "enable/disable layer mask(s)"
-msgstr "Ebenenmasken de-/aktivieren"
-
-#: src/gui/operation_config_gui.cc:252 src/gui/operation_config_gui.cc:253
-#, fuzzy
-msgid "toggle sticky flag on/off"
-msgstr "Sticky-Flag an/aus"
-
-#: src/gui/operation_config_gui.cc:254 src/gui/operation_config_gui.cc:255
-msgid "toggle editing flag on/off"
-msgstr "Bearbeiten an/aus"
-
-#: src/gui/operation_config_gui.cc:256
-msgid "reset tool parameters"
-msgstr "Werkzeugeinstellungen zurücksetzen"
-
-#: src/gui/operation_config_gui.cc:257 src/gui/operation_config_gui.cc:258
-msgid "show information on current tool"
-msgstr "Informationen zum aktuellen Werkzeug anzeigen"
-
-#: src/gui/operation_config_gui.cc:700
-msgid "Close"
-msgstr "Schließen"
-
-#: src/gui/layerwidget.cc:115 src/gui/mainwindow.cc:100
-msgid "New Adjustment"
-msgstr "Neue Korrektur"
-
-#: src/gui/layerwidget.cc:118
-msgid "Load preset"
-msgstr "Preset laden"
-
-#: src/gui/layerwidget.cc:119
-msgid "Save preset"
-msgstr "Preset speichern"
-
-#: src/gui/layerwidget.cc:140
-msgid "new layer"
-msgstr "Neue Ebene"
-
-#: src/gui/layerwidget.cc:141
-msgid "new group layer"
-msgstr "Neue Ebenengruppe"
-
-#: src/gui/layerwidget.cc:142
-msgid "delete layer"
-msgstr "Ebene löschen"
-
-#: src/gui/layerwidget.cc:143
-msgid "basic editing"
-msgstr "Grundlegende Bearbeitung"
-
-#: src/gui/layerwidget.cc:144
-msgid "curves tool"
-msgstr "Gradationskurve"
-
-#: src/gui/layerwidget.cc:146
-msgid "gradient tool"
-msgstr "Verlaufswerkzeug"
-
-#: src/gui/layerwidget.cc:147
-msgid "desaturate tool"
-msgstr "Entsättigen"
-
-#: src/gui/layerwidget.cc:148
-msgid "crop tool"
-msgstr "Freistellungswerkzeug"
-
-#: src/gui/layerwidget.cc:150
-msgid "clone stamp tool"
-msgstr "Klonstempel"
-
-#: src/gui/layerwidget.cc:152
-msgid "scale/rotate tool"
-msgstr "Skalieren-und-Rotieren-Werkzeug"
-
-#: src/gui/layerwidget.cc:153
-msgid "path tool"
-msgstr "Pfadwerkzeug"
-
-#: src/gui/layerwidget.cc:177
-msgid "Layers"
-msgstr "Ebenen"
-
-#: src/gui/layerwidget.cc:188
-msgid "Add a new layer"
-msgstr "Neue Ebene hinzufügen"
-
-#: src/gui/layerwidget.cc:190
-msgid "Add a new layer group"
-msgstr "Neue Ebenengruppe hinzufügen"
-
-#: src/gui/layerwidget.cc:192
-msgid "Remove selected layers"
-msgstr "Ausgewählte Ebenen entfernen"
-
-#: src/gui/layerwidget.cc:194
-msgid "Load an existing preset"
-msgstr "Eine Voreinstellung laden"
-
-#: src/gui/layerwidget.cc:196
-msgid "Save the selected layers as a preset"
-msgstr "Die ausgewählten Ebenen als Voreinstellung speichern"
-
-#: src/gui/layerwidget.cc:994
-msgid "New Group Layer"
-msgstr "Neue Ebenengruppe"
-
-#: src/gui/layerwidget.cc:1004
-msgid "Group Layer Config"
-msgstr "Ebenengruppenkonfiguration"
-
-#: src/gui/layerwidget.cc:1034 src/gui/layerwidget.cc:1039
-#: src/gui/layerwidget.cc:1102 src/gui/layerwidget.cc:1107
-msgid "Photoflow presets"
-msgstr "Photoflow-Voreinstellungen"
-
-#: src/gui/layerwidget.cc:1092
-msgid "Save preset as..."
-msgstr "Voreinstellung speichern unter..."
-
 #: src/gui/widgets/outmode_slider.cc:60
 msgid "preserve colors"
 msgstr "Farben erhalten"
 
-#: src/gui/mainwindow.cc:79
-msgid "files"
-msgstr "Dateien"
+#: src/base/image.cc:688
+msgid "background"
+msgstr "Hintergrund"
 
-#: src/gui/mainwindow.cc:80
-msgid "editing"
-msgstr "Bearbeite"
+#: src/base/pftypes.cc:56 src/base/pftypes.cc:65
+msgid "Passthrough"
+msgstr "Durchreichen"
 
-#: src/gui/mainwindow.cc:101
-msgid "New Group"
-msgstr "Neue Ebenengruppe"
+#: src/base/pftypes.cc:57 src/base/pftypes.cc:66
+msgid "Normal"
+msgstr "Normal"
 
-#: src/gui/mainwindow.cc:137 src/gui/mainwindow.cc:161
-#: src/gui/mainwindow.cc:164
-msgid "Open existing file"
-msgstr "Vorhandene Datei öffnen"
+#: src/base/pftypes.cc:59 src/base/pftypes.cc:68
+msgid "Grain extract"
+msgstr "Körnung extrahieren"
 
-#: src/gui/mainwindow.cc:139
-msgid "Save current image"
-msgstr "Bild speichern"
+#: src/base/pftypes.cc:60 src/base/pftypes.cc:69
+msgid "Grain merge"
+msgstr "Körnung mischen"
 
-#: src/gui/mainwindow.cc:141
-msgid "Save current image with a different name"
-msgstr "Bild unter anderem Namen speichern"
+#: src/base/pftypes.cc:61 src/base/pftypes.cc:70
+msgid "Overlay"
+msgstr "Überlagern"
 
-#: src/gui/mainwindow.cc:143
-msgid "Export current image to raster format"
-msgstr "Aktuelles Bild in ein Rasterformat exportieren"
+#: src/base/pftypes.cc:63 src/base/pftypes.cc:72
+msgid "Soft light"
+msgstr "Weiches Licht"
 
-#: src/gui/mainwindow.cc:145
-msgid "Open settings dialog"
-msgstr "Einstellungen-Dialog öffnen"
+#: src/base/pftypes.cc:64 src/base/pftypes.cc:73
+msgid "Hard light"
+msgstr "Hartes Licht"
 
-#: src/gui/mainwindow.cc:147
-msgid "Exit PhotoFlow"
-msgstr "PhotoFlow beenden"
+#: src/base/pftypes.cc:65 src/base/pftypes.cc:74
+msgid "Vivid light"
+msgstr "Strahlendes Licht"
 
-#: src/gui/mainwindow.cc:266
-msgid "Export"
-msgstr "Exportieren"
+#: src/base/pftypes.cc:66 src/base/pftypes.cc:75
+msgid "Multiply"
+msgstr "Multiplikation"
 
-#: src/gui/mainwindow.cc:567 src/gui/mainwindow.cc:625
-msgid "Image files"
-msgstr "Bilddateien"
+# I've used the PS term here as it is a bit better to understand than GIMP's translation "Bildschirm"
+#: src/base/pftypes.cc:67 src/base/pftypes.cc:76
+msgid "Screen"
+msgstr "Negativ multiplizieren"
 
-#: src/gui/mainwindow.cc:620 src/gui/mainwindow.cc:678
-msgid "All files"
-msgstr "Alle Dateien"
+#: src/base/pftypes.cc:68 src/base/pftypes.cc:77
+msgid "Lighten"
+msgstr "Aufhellen"
 
-#: src/gui/mainwindow.cc:750
-msgid "Save image as..."
-msgstr "Bild speichern unter..."
+#: src/base/pftypes.cc:69 src/base/pftypes.cc:78
+msgid "Darken"
+msgstr "Abdunkeln"
 
-#: src/gui/mainwindow.cc:766 src/gui/mainwindow.cc:771
-msgid "Photoflow files"
-msgstr "Photoflow-Dateien"
+#: src/base/pftypes.cc:71 src/base/pftypes.cc:80
+msgid "Color"
+msgstr "Farbe"
 
-#: src/gui/mainwindow.cc:853
-msgid "Export image as..."
-msgstr "Bild exportieren als..."
+#: src/gui/settingsdialog.cc:67
+msgid "Color management"
+msgstr "Colormanagement"
 
-#: src/gui/mainwindow.cc:863 src/gui/mainwindow.cc:868
-msgid "JPEG files"
-msgstr "JPEG-Dateien"
+#: src/gui/settingsdialog.cc:68
+msgid "About"
+msgstr "Über"
 
-#: src/gui/mainwindow.cc:875 src/gui/mainwindow.cc:880
-msgid "TIFF files"
-msgstr "TIFF-Dateien"
+#: src/gui/settingsdialog.cc:212
+msgid "Please choose an ICC profile"
+msgstr "ICC-Farbprofil auswählen"
 
-#: src/gui/mainwindow.cc:981
-#, c-format
-msgid ""
-"Image \"%s\" contains unsaved data. Do you want to save it before closing?"
-msgstr ""
-"Das Bild \"%s\" enthält ungesicherte Änderungen. Möchten Sie diese vor dem "
-"Beenden speichern?"
+#: src/operations/scale.cc:199
+msgid "Fit"
+msgstr "Einpassen"
 
-#~ msgid "Load"
-#~ msgstr "Laden"
+#: src/operations/scale.cc:200
+msgid "percent"
+msgstr "Prozent"
 
-#~ msgid "Save"
-#~ msgstr "Speichern"
+#: src/operations/scale.cc:217
+msgid "pixels"
+msgstr "Pixel"
 
-#~ msgid "Open"
-#~ msgstr "ffnen"
+#: src/operations/scale.cc:218
+msgid "mm"
+msgstr "mm"
 
-#~ msgid "Save as"
-#~ msgstr "Speichern unter"
+#: src/operations/scale.cc:219
+msgid "cm"
+msgstr "cm"
 
-#~ msgid "Exit"
-#~ msgstr "Beenden"
+#: src/operations/scale.cc:220
+msgid "inches"
+msgstr "Zoll"
 
-#~ msgid "feather radius"
-#~ msgstr "Ausblenderadius"
+#: src/gui/operations/clone_config.cc:38
+msgid "Source channel: "
+msgstr "Quellkanal:"
 
-#~ msgid "Extract Foreground"
-#~ msgstr "Vordergrund freistellen"
+#: src/gui/operations/clone_stamp_config.cc:38
+msgid "Stamp size: "
+msgstr "Stempelgröße:"
 
-#~ msgid "Iain's Noise Reduction"
-#~ msgstr "Rauschreduzierung (Iain)"
+#: src/gui/operations/clone_stamp_config.cc:39
+msgid "Stamp opacity: "
+msgstr "Stempeldeckkraft:"
+
+#: src/gui/operations/clone_stamp_config.cc:40
+msgid "Stamp smoothness: "
+msgstr "Kantenweichheit:"
+
+#: src/gui/operations/clone_stamp_config.cc:41
+#: src/gui/operations/draw_config.cc:52
+msgid "Undo"
+msgstr "Rückgängig"
+
+#: src/gui/operations/uniform_config.cc:38
+msgid "Color:              "
+msgstr "Farbe:              "
+
+#: src/gui/operations/gradient_config.cc:46
+msgid "Gradient tool"
+msgstr "Verlaufswerkzeug"
+
+#: src/gui/operations/gradient_config.cc:47
+msgid "Type:) "
+msgstr "Typ:"
+
+#: src/gui/operations/gradient_config.cc:49
+msgid "Center X (%)"
+msgstr "Mittelpunkt X (%)"
+
+#: src/gui/operations/gradient_config.cc:50
+msgid "Center Y (%))"
+msgstr "Mittelpunkt Y (%)"
+
+#: src/gui/operations/crop_config.cc:38
+msgid "Crop left"
+msgstr "Links"
+
+#: src/gui/operations/crop_config.cc:39
+msgid "Crop top"
+msgstr "Oben"
+
+#: src/gui/operations/crop_config.cc:40
+msgid "Crop width"
+msgstr "Breite"
+
+#: src/gui/operations/crop_config.cc:41
+msgid "Crop height"
+msgstr "Höhe"
+
+#: src/gui/operations/crop_config.cc:42
+msgid "Keep aspect ratio"
+msgstr "Seitenverhältnis beibehalten"
+
+#: src/gui/operations/crop_config.cc:43
+msgid "Aspect ratio: W="
+msgstr "Seitenverhältnis: B="
+
+#: src/gui/operations/crop_config.cc:44
+msgid "/H="
+msgstr "/H="
+
+#: src/gui/operations/gradient_config.cc:47
+msgid "Type: "
+msgstr "Typ:"
+
+#: src/gui/operations/gradient_config.cc:50
+msgid "Center Y (%)"
+msgstr "Mittelpunkt Y (%)"
+
+#: src/gui/operations/desaturate_config.cc:35
+msgid "Desaturate method: "
+msgstr "Entsättigungsmethode: "
+
+#: src/gui/operations/draw_config.cc:38
+msgid "Pen color:              "
+msgstr "Stiftfarbe:              "
+
+#: src/gui/operations/draw_config.cc:39
+msgid "Background color: "
+msgstr "Hintergrundfarbe: "
+
+#: src/gui/operations/draw_config.cc:49
+msgid "Pen size: "
+msgstr "Stiftgröße: "
+
+#: src/gui/operations/draw_config.cc:50
+msgid "Pen opacity: "
+msgstr "Stiftdeckkraft: "
+
+#: src/gui/operations/draw_config.cc:51
+msgid "pen smoothness: "
+msgstr "Weichheit: "
+
+#: src/gui/operationstree.cc:208 src/gui/operation_config_gui.cc:688
+#: src/gui/operation_config_gui.cc:689
+msgid "This help is not yet available. Sorry."
+msgstr "Entschuldigung, hierfür ist noch keine Hilfe vorhanden."
+
+#: src/gui/layerwidget.cc:497 src/gui/layerwidget.cc:496
+msgid "opacity ("
+msgstr "Deckkraft ("
+
+#: src/gui/settingsdialog.cc:89
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: src/gui/layerwidget.cc:1280 src/gui/layerwidget.cc:1279
+msgid "Open preset"
+msgstr "Preset laden"
+
+#: src/gui/widgets/curveeditor.cc:42
+msgid "in: "
+msgstr "Eingabe"
+
+#: src/gui/widgets/curveeditor.cc:43
+msgid "out: "
+msgstr "Ausgabe"
+
+#: src/gui/operations/curves_config.cc:51
+#: src/gui/operations/brightness_contrast_config.cc:43
+msgid "Output mode"
+msgstr "Ausgabemodus"
+
+#: src/gui/operation_config_gui.cc:669 src/gui/operation_config_gui.cc:670
+msgid "help"
+msgstr "Hilfe"
+
+#: src/gui/layerwidget.cc:449 src/gui/layerwidget.cc:448
+msgid "intensity ("
+msgstr "Effektstärke ("
+
+#: src/gui/layerwidget.cc:964 src/gui/layerwidget.cc:963
+msgid "image file"
+msgstr "Bilddatei"

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,917 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-04 21:54+0200\n"
+"PO-Revision-Date: 2016-09-05 06:52+0200\n"
+"Last-Translator: Sven Claussner <scl.gplus@gmail.com>\n"
+"Language-Team: German <LL@li.org>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.8\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#: src/operations/brightness_contrast_par.hh:12
+msgid "brightness contrast"
+msgstr "Helligkeit Kontrast"
+
+#: src/operations/image_reader.hh:71
+msgid "image layer"
+msgstr "Bildebene"
+
+#: src/operations/channel_mixer.hh:51
+msgid "channel mixer"
+msgstr "Kanalmixer"
+
+#: src/operations/hue_saturation.cc:72
+msgid "B-C-S-H adjustment"
+msgstr "Farb- und Tonwerteinstellungen"
+
+#: src/operations/icc_transform.cc:42
+msgid "ICC transform"
+msgstr "Farbraumumwandlung"
+
+#: src/operations/impulse_nr.cc:52 src/gui/operations/denoise_config.cc:38
+msgid "impulse NR"
+msgstr "Impulsrauschen reduzieren"
+
+# A non-standard word for lightness.
+#: src/operations/desaturate.cc:37
+msgid "Luminosity"
+msgstr "Helligkeit"
+
+#: src/operations/desaturate.cc:39
+msgid "Lightness"
+msgstr "Helligkeit"
+
+#: src/operations/desaturate.cc:40
+msgid "Average"
+msgstr "Durchschnitt"
+
+#: src/operations/desaturate.cc:41
+msgid "Lab L channel"
+msgstr "Lab-L-Kanal"
+
+#: src/operations/desaturate.cc:51
+msgid "desaturate"
+msgstr "Entsättigen"
+
+#: src/operations/path_mask.cc:209
+msgid "path mask"
+msgstr "Vektormaske"
+
+#: src/operations/sharpen.cc:59
+msgid "sharpening"
+msgstr "Schärfen"
+
+#: src/operations/raw_developer.cc:75 src/gui/operationstree.cc:297
+msgid "RAW developer"
+msgstr "RAW-Entwickler"
+
+#: src/operations/invert.cc:38 src/gui/operations/threshold_config.cc:38
+#: src/gui/operations/path_mask_config.cc:47
+msgid "invert"
+msgstr "Invertieren"
+
+#: src/operations/convert_colorspace.cc:71
+msgid "colorspace conversion"
+msgstr "Farbraumumwandlung"
+
+#: src/operations/lensfun.cc:62
+msgid "optical corrections"
+msgstr "Optische Korrekturen"
+
+#: src/operations/scale.cc:224
+msgid "scale and rotate"
+msgstr "Skalieren und rotieren"
+
+#: src/operations/draw.cc:68 src/gui/layerwidget.cc:149
+msgid "freehand drawing"
+msgstr "Freihandzeichnung"
+
+#: src/operations/clone.cc:63
+msgid "layer clone"
+msgstr "Geklonte Ebene"
+
+#: src/operations/hsl_mask.cc:48
+msgid "HSL mask"
+msgstr "HSL-Maske"
+
+#: src/operations/perspective.cc:51 src/gui/layerwidget.cc:151
+msgid "perspective correction"
+msgstr "Perspektivkorrektur"
+
+#: src/operations/denoise.cc:52
+msgid "noise reduction"
+msgstr "Rauschreduzierung"
+
+#: src/operations/uniform.cc:49 src/gui/layerwidget.cc:145
+msgid "uniform fill"
+msgstr "Gleichmäßige Füllung"
+
+#: src/operations/clone_stamp.cc:46
+msgid "clone stamp"
+msgstr "Klonpinsel"
+
+#: src/operations/raw_output.cc:57
+msgid "clip"
+msgstr "Abschneiden"
+
+#: src/operations/raw_output.cc:75
+msgid "blend"
+msgstr "Überblenden"
+
+#: src/operations/raw_output.cc:76
+msgid "none"
+msgstr "Keine(r)"
+
+#: src/operations/gradient.cc:36
+msgid "Vertical"
+msgstr "vertikal"
+
+#: src/operations/gradient.cc:60
+msgid "Horizontal"
+msgstr "horizontal"
+
+#: src/operations/gradient.cc:61
+msgid "Radial"
+msgstr "radial"
+
+#: src/operations/gradient.cc:86
+msgid "gradient"
+msgstr "Verlauf"
+
+#: src/operations/crop.cc:46
+msgid "crop"
+msgstr "Beschneiden"
+
+#: src/operations/volume.cc:74
+msgid "local contrast"
+msgstr "Lokaler Kontrast"
+
+#: src/operations/threshold.cc:39 src/gui/operations/denoise_config.cc:39
+#: src/gui/operations/threshold_config.cc:37
+msgid "threshold"
+msgstr "Schwellwert"
+
+#: src/operations/gaussblur.cc:50
+msgid "gaussian blur"
+msgstr "Gauß'scher Weichzeichner"
+
+#: src/operations/curves.cc:74
+msgid "curves"
+msgstr "Gradationskurve"
+
+#: src/gui/imageeditor.hh:177
+msgid "ready"
+msgstr "Bereit"
+
+#: src/gui/imageeditor.hh:178
+msgid "caching"
+msgstr "Zwischenspeichern"
+
+#: src/gui/imageeditor.hh:179
+msgid "processing"
+msgstr "Verarbeite"
+
+#: src/gui/imageeditor.hh:180
+msgid "exporting"
+msgstr "Exportiere"
+
+#: src/gui/imageeditor.cc:144
+msgid "show merged layers"
+msgstr "Vereinte Ebenen anzeigen"
+
+#: src/gui/imageeditor.cc:145
+msgid "show active layer"
+msgstr "Aktive Ebene anzeigen"
+
+#: src/gui/imageeditor.cc:193
+msgid "Toggle highlights clipping warning on/off"
+msgstr "Lichterwarnung an/aus"
+
+#: src/gui/imageeditor.cc:197
+msgid "Toggle shadows clipping warning on/off"
+msgstr "Tiefenwarnung an/aus"
+
+#: src/gui/imageeditor.cc:203
+msgid "Zoom to 100%"
+msgstr "Auf 100% zoomen"
+
+#: src/gui/imageeditor.cc:207
+msgid "Fit image to preview area"
+msgstr "Bild in Ansicht einpassen"
+
+#: src/gui/imageeditor.cc:211
+msgid "Zoom out"
+msgstr "Herauszoomen"
+
+#: src/gui/imageeditor.cc:215
+msgid "Zoom in"
+msgstr "Hineinzoomen"
+
+#: src/gui/imageeditor.cc:224
+msgid "histogram"
+msgstr "Histogramm"
+
+#: src/gui/imageeditor.cc:481
+#, c-format
+msgid "Crash recovery found for file \"%s\". Do you want to restore it?"
+msgstr ""
+"Wiederherstellbare Datei \"%s\" gefunden. Möchten Sie sie wiederherstellen?"
+
+#: src/gui/operations/hsl_mask_config.cc:86
+msgid "HSL Mask"
+msgstr "HSL-Maske"
+
+#: src/gui/operations/hsl_mask_config.cc:94
+msgid "Layer name:"
+msgstr "Ebenenname"
+
+#: src/gui/operations/raw_developer_config.cc:333
+msgid "temperature"
+msgstr "Farbtemperatur"
+
+#: src/gui/operations/raw_developer_config.cc:334
+msgid "tint"
+msgstr "Einfärben"
+
+#: src/gui/operations/raw_developer_config.cc:344
+msgid "enable CA correction"
+msgstr "Chromatische Abberation korrigieren"
+
+#: src/gui/operations/raw_developer_config.cc:345
+msgid "auto"
+msgstr "Auto"
+
+#: src/gui/operations/raw_developer_config.cc:346
+msgid "red"
+msgstr "rot"
+
+#: src/gui/operations/raw_developer_config.cc:347
+msgid "blue"
+msgstr "blau"
+
+#: src/gui/operations/raw_developer_config.cc:348
+msgid "method: "
+msgstr "Methode"
+
+#: src/gui/operations/raw_developer_config.cc:351
+msgid "RAW white level %"
+msgstr "RAW-Weißpunkt %"
+
+#: src/gui/operations/raw_developer_config.cc:352
+msgid "RAW black level %"
+msgstr "RAW-Schwarzpunkt %"
+
+#: src/gui/operations/raw_developer_config.cc:353
+msgid "highlights reco: "
+msgstr "Lichter restaurieren:"
+
+#: src/gui/operations/raw_developer_config.cc:354
+msgid "input: "
+msgstr "Eingabe:"
+
+#: src/gui/operations/raw_developer_config.cc:359
+msgid "working profile: "
+msgstr "Arbeitsprofil"
+
+#: src/gui/operations/curves_config.cc:56
+#: src/gui/operations/curves_config.cc:75
+#: src/gui/operations/gradient_config.cc:68
+#: src/gui/operations/gradient_config.cc:81
+msgid "RGB"
+msgstr "RGB"
+
+#: src/gui/operations/curves_config.cc:57
+#: src/gui/operations/curves_config.cc:76
+#: src/gui/operations/gradient_config.cc:69
+#: src/gui/operations/gradient_config.cc:82
+msgid "Red"
+msgstr "Rot"
+
+#: src/gui/operations/curves_config.cc:58
+#: src/gui/operations/curves_config.cc:77
+#: src/gui/operations/gradient_config.cc:70
+#: src/gui/operations/gradient_config.cc:83
+msgid "Green"
+msgstr "Grün"
+
+#: src/gui/operations/curves_config.cc:59
+#: src/gui/operations/curves_config.cc:78
+#: src/gui/operations/gradient_config.cc:71
+#: src/gui/operations/gradient_config.cc:84
+msgid "Blue"
+msgstr "Blau"
+
+#: src/gui/operations/scale_config.cc:37
+msgid "flip vertically"
+msgstr "Vertikal spiegeln"
+
+#: src/gui/operations/scale_config.cc:38
+msgid "flip horizontally"
+msgstr "Horizontal spiegeln"
+
+#: src/gui/operations/scale_config.cc:39
+msgid "rotation angle"
+msgstr "Winkel"
+
+#: src/gui/operations/scale_config.cc:40
+msgid "auto crop"
+msgstr "Automatisch beschneiden"
+
+#: src/gui/operations/scale_config.cc:41
+msgid "scale mode: "
+msgstr "Modus:"
+
+#: src/gui/operations/scale_config.cc:42
+msgid "unit: "
+msgstr "Einheit:"
+
+#: src/gui/operations/scale_config.cc:43 src/gui/operations/scale_config.cc:45
+msgid "width: "
+msgstr "Breite:"
+
+#: src/gui/operations/scale_config.cc:44 src/gui/operations/scale_config.cc:46
+msgid "height: "
+msgstr "Höhe:"
+
+#: src/gui/operations/scale_config.cc:47 src/gui/operations/scale_config.cc:49
+#: src/gui/operations/scale_config.cc:51
+msgid "W: "
+msgstr "B:"
+
+#: src/gui/operations/scale_config.cc:48 src/gui/operations/scale_config.cc:50
+#: src/gui/operations/scale_config.cc:52
+msgid "H: "
+msgstr "H:"
+
+#: src/gui/operations/scale_config.cc:53
+msgid "resolution: "
+msgstr "Auflösung:"
+
+#: src/gui/operations/imageread_config.cc:40
+msgid "file name:"
+msgstr "Dateiname:"
+
+#: src/gui/operations/hue_saturation_config.cc:87
+msgid "Brightness"
+msgstr "Hellligkeit"
+
+#: src/gui/operations/hue_saturation_config.cc:89
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: src/gui/operations/hue_saturation_config.cc:91
+msgid "Saturation"
+msgstr "Sättigung"
+
+#: src/gui/operations/hue_saturation_config.cc:93
+msgid "Hue"
+msgstr "Farbton"
+
+#: src/gui/operations/hue_saturation_config.cc:95
+msgid "show mask"
+msgstr "Maske anzeigen"
+
+#: src/gui/operations/hue_saturation_config.cc:99
+#: src/gui/operations/hue_saturation_config.cc:100
+#: src/gui/operations/hue_saturation_config.cc:101
+msgid "Enable"
+msgstr "Aktivieren"
+
+#: src/gui/operations/hue_saturation_config.cc:108
+msgid "feather"
+msgstr "Weiche Kante"
+
+#: src/gui/operations/hue_saturation_config.cc:109
+msgid "radius "
+msgstr "Radius"
+
+#: src/gui/operations/hue_saturation_config.cc:110
+msgid "invert mask"
+msgstr "Maske invertieren"
+
+#: src/gui/operations/hue_saturation_config.cc:125
+msgid "H curve"
+msgstr "H-Kurve"
+
+#: src/gui/operations/hue_saturation_config.cc:126
+msgid "S curve"
+msgstr "S-Kurve"
+
+#: src/gui/operations/hue_saturation_config.cc:127
+msgid "L curve"
+msgstr "L-Kurve"
+
+#: src/gui/operations/hue_saturation_config.cc:143
+msgid "HSL curves"
+msgstr "HSL-Kurven"
+
+#: src/gui/operations/path_mask_config.cc:48
+msgid "enable falloff"
+msgstr "Weiche Kante"
+
+#: src/gui/operationstree.cc:246
+msgid "Add New Layer"
+msgstr "Neue Ebene hinzufügen"
+
+#: src/gui/operationstree.cc:252 src/gui/settingsdialog.cc:61
+msgid "OK"
+msgstr "OK"
+
+#: src/gui/operationstree.cc:253 src/gui/settingsdialog.cc:62
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: src/gui/operationstree.cc:295 src/gui/mainwindow.cc:552
+msgid "Open image"
+msgstr "Bild öffnen"
+
+#: src/gui/operationstree.cc:296
+msgid "Open RAW image"
+msgstr "RAW-Datei öffnen"
+
+#: src/gui/operationstree.cc:302
+msgid "Color profile conversion"
+msgstr "Farbprofilumwandlung"
+
+#: src/gui/operationstree.cc:303
+msgid "Basic Adjustments"
+msgstr "Grundlegende Korrekturen"
+
+#: src/gui/operationstree.cc:304 src/gui/operationstree.cc:364
+msgid "Curves"
+msgstr "Kurven"
+
+#: src/gui/operationstree.cc:305 src/gui/operationstree.cc:362
+msgid "Invert"
+msgstr "Invertieren"
+
+#: src/gui/operationstree.cc:306
+msgid "Desaturate"
+msgstr "Entsättigen"
+
+#: src/gui/operationstree.cc:307 src/gui/operationstree.cc:363
+msgid "Threshold"
+msgstr "Schwellwert"
+
+#: src/gui/operationstree.cc:309
+msgid "Channel Mixer"
+msgstr "Kanalmixer"
+
+#: src/gui/operationstree.cc:310 src/gui/operationstree.cc:361
+msgid "Uniform Fill"
+msgstr "Gleichmäßige Füllung"
+
+#: src/gui/operationstree.cc:311 src/gui/operationstree.cc:365
+msgid "Gradient"
+msgstr "Verlauf"
+
+#: src/gui/operationstree.cc:312 src/gui/operationstree.cc:367
+msgid "H/S/L Mask"
+msgstr "H/S/L-Maske"
+
+#: src/gui/operationstree.cc:313
+msgid "Emulate film [color slide]"
+msgstr "Farbfilm emulieren"
+
+#: src/gui/operationstree.cc:314
+msgid "Emulate film [B&W]"
+msgstr "Schwarzweißfilm emulieren"
+
+#: src/gui/operationstree.cc:315
+msgid "Emulate film [instant consumer]"
+msgstr "Consumer-Sofortbildfilm emulieren"
+
+#: src/gui/operationstree.cc:316
+msgid "Emulate film [instant pro]"
+msgstr "Professionellen Sofortbildfilm emulieren"
+
+#: src/gui/operationstree.cc:317
+msgid "Emulate film [negative color]"
+msgstr "Farbnegativfilm emulieren"
+
+#: src/gui/operationstree.cc:318
+msgid "Emulate film [negative new]"
+msgstr "Negativfilm (neueres Modell) emulieren"
+
+#: src/gui/operationstree.cc:319
+msgid "Emulate film [negative old]"
+msgstr "Negativfilm (älteres Modell) emulieren"
+
+#: src/gui/operationstree.cc:320
+msgid "Emulate film [print films]"
+msgstr "Printfilm emulieren"
+
+#: src/gui/operationstree.cc:321
+msgid "Emulate film [various]"
+msgstr "Verschiedene Filme emulieren"
+
+#: src/gui/operationstree.cc:323 src/gui/operationstree.cc:368
+msgid "Gaussian blur"
+msgstr "Gauß'scher Weichzeichner"
+
+#: src/gui/operationstree.cc:324
+msgid "Local contrast"
+msgstr "Lokaler Kontrast"
+
+#: src/gui/operationstree.cc:325
+msgid "Sharpen"
+msgstr "Schärfen"
+
+#: src/gui/operationstree.cc:326 src/gui/operationstree.cc:339
+#: src/gui/operationstree.cc:372
+msgid "Gradient Norm"
+msgstr ""
+
+#: src/gui/operationstree.cc:327
+msgid "Multi-level decomposition"
+msgstr "Bild zerlegen"
+
+#: src/gui/operationstree.cc:328
+msgid "Noise reduction"
+msgstr "Rauschreduzierung"
+
+#: src/gui/operationstree.cc:330
+msgid "Crop image"
+msgstr "Bild beschneiden"
+
+#: src/gui/operationstree.cc:331
+msgid "Scale & rotate image"
+msgstr "Bild skalieren und rotieren"
+
+#: src/gui/operationstree.cc:332
+msgid "Perspective correction"
+msgstr "Perspektivkorrektur"
+
+#: src/gui/operationstree.cc:333
+msgid "Optical corrections (experimental)"
+msgstr "Optische Korrekturen (experimentell)"
+
+#: src/gui/operationstree.cc:338
+msgid "Dream Smoothing"
+msgstr "Träumerische Weichzeichnung"
+
+#: src/gui/operationstree.cc:345
+msgid "Sharpen [richardson-lucy]"
+msgstr "Schärfen (Richardson-Lucy-Algorithmus)"
+
+#: src/gui/operationstree.cc:346
+msgid "Smooth [anisotropic]"
+msgstr "Weichzeichnen (anisotropisch)"
+
+#: src/gui/operationstree.cc:347
+msgid "Smooth [bilateral]"
+msgstr "Weichzeichnen (bilateral)"
+
+#: src/gui/operationstree.cc:348
+msgid "Smooth [diffusion]"
+msgstr "Weichzeichnen (Diffusion)"
+
+#: src/gui/operationstree.cc:349
+msgid "Smooth [mean-curvature]"
+msgstr "Weichzeichnen (Durchschnitt)"
+
+#: src/gui/operationstree.cc:350
+msgid "Smooth [median]"
+msgstr "Weichzeichnen (Median)"
+
+#: src/gui/operationstree.cc:351
+msgid "Smooth [patch-based]"
+msgstr "Weichzeichnen (Patch-basiert)"
+
+#: src/gui/operationstree.cc:352
+msgid "Smooth [selective gaussian]"
+msgstr "Weichzeichnen (selektiv)"
+
+#: src/gui/operationstree.cc:353
+msgid "Smooth [total variation]"
+msgstr "Weichzeichnen (total variation)"
+
+#: src/gui/operationstree.cc:354
+msgid "Smooth [wavelets]"
+msgstr "Weichzeichnen (wavelet-basiert)"
+
+#: src/gui/operationstree.cc:355
+msgid "Smooth [guided]"
+msgstr "Weichzeichnen (geführt)"
+
+#: src/gui/operationstree.cc:356
+msgid "Tone mapping"
+msgstr "Tonemapping"
+
+#: src/gui/operationstree.cc:357
+msgid "Transfer colors [advanced]"
+msgstr "Farben übertragen (fortgeschritten)"
+
+#: src/gui/operationstree.cc:366
+msgid "Path"
+msgstr "Pfad"
+
+#: src/gui/operationstree.cc:374 src/gui/operationstree.cc:379
+msgid "Draw"
+msgstr "Zeichnen"
+
+#: src/gui/operationstree.cc:375 src/gui/operationstree.cc:381
+msgid "Clone layer"
+msgstr "Ebene klonen"
+
+#: src/gui/operationstree.cc:380
+msgid "Clone stamp"
+msgstr "Klonstempel"
+
+#: src/gui/operationstree.cc:382
+msgid "Buffer layer"
+msgstr "Zwischenspeicher"
+
+#: src/gui/operationstree.cc:383
+msgid "Digital watermark"
+msgstr "Digitales Wasserzeichen"
+
+#: src/gui/operationstree.cc:503 src/gui/widgets/toolbutton.cc:103
+msgid "New Layer"
+msgstr "Neue Ebene"
+
+#: src/gui/settingsdialog.cc:56
+msgid "Settings"
+msgstr "Einstellungen"
+
+#: src/gui/settingsdialog.cc:92
+msgid "custom display profile name: "
+msgstr "Benutzerdefiniertes Bildschirmprofil: "
+
+#: src/gui/settingsdialog.cc:100
+msgid "display profile type: "
+msgstr "Bildschirmprofil: "
+
+#: src/gui/operation_config_gui.cc:82 src/gui/operation_config_gui.cc:83
+msgid "Intensity"
+msgstr "Intensität"
+
+#: src/gui/operation_config_gui.cc:84 src/gui/operation_config_gui.cc:85
+msgid "Opacity"
+msgstr "Deckkraft"
+
+#: src/gui/operation_config_gui.cc:86 src/gui/operation_config_gui.cc:87
+msgid "Enable mask"
+msgstr "Maske aktivieren"
+
+#: src/gui/operation_config_gui.cc:88
+msgid "X shift "
+msgstr "X-Offset"
+
+#: src/gui/operation_config_gui.cc:89
+msgid "Y shift "
+msgstr "Y-Offset"
+
+#: src/gui/operation_config_gui.cc:91 src/gui/operation_config_gui.cc:92
+#: src/gui/operation_config_gui.cc:93
+msgid "Target channel: "
+msgstr "Ziel-Kanal: "
+
+#: src/gui/operation_config_gui.cc:94
+msgid "Target channel:"
+msgstr "Ziel-Kanal:"
+
+#: src/gui/operation_config_gui.cc:95
+msgid "preview"
+msgstr "Vorschau"
+
+#: src/gui/operation_config_gui.cc:249
+msgid "toggle layer visibility on/off"
+msgstr "Ebenen ein-/ausblenden"
+
+#: src/gui/operation_config_gui.cc:250 src/gui/operation_config_gui.cc:251
+msgid "enable/disable layer mask(s)"
+msgstr "Ebenenmasken de-/aktivieren"
+
+#: src/gui/operation_config_gui.cc:252 src/gui/operation_config_gui.cc:253
+#, fuzzy
+msgid "toggle sticky flag on/off"
+msgstr "Sticky-Flag an/aus"
+
+#: src/gui/operation_config_gui.cc:254 src/gui/operation_config_gui.cc:255
+msgid "toggle editing flag on/off"
+msgstr "Bearbeiten an/aus"
+
+#: src/gui/operation_config_gui.cc:256
+msgid "reset tool parameters"
+msgstr "Werkzeugeinstellungen zurücksetzen"
+
+#: src/gui/operation_config_gui.cc:257 src/gui/operation_config_gui.cc:258
+msgid "show information on current tool"
+msgstr "Informationen zum aktuellen Werkzeug anzeigen"
+
+#: src/gui/operation_config_gui.cc:700
+msgid "Close"
+msgstr "Schließen"
+
+#: src/gui/layerwidget.cc:115 src/gui/mainwindow.cc:100
+msgid "New Adjustment"
+msgstr "Neue Korrektur"
+
+#: src/gui/layerwidget.cc:118
+msgid "Load preset"
+msgstr "Preset laden"
+
+#: src/gui/layerwidget.cc:119
+msgid "Save preset"
+msgstr "Preset speichern"
+
+#: src/gui/layerwidget.cc:140
+msgid "new layer"
+msgstr "Neue Ebene"
+
+#: src/gui/layerwidget.cc:141
+msgid "new group layer"
+msgstr "Neue Ebenengruppe"
+
+#: src/gui/layerwidget.cc:142
+msgid "delete layer"
+msgstr "Ebene löschen"
+
+#: src/gui/layerwidget.cc:143
+msgid "basic editing"
+msgstr "Grundlegende Bearbeitung"
+
+#: src/gui/layerwidget.cc:144
+msgid "curves tool"
+msgstr "Gradationskurve"
+
+#: src/gui/layerwidget.cc:146
+msgid "gradient tool"
+msgstr "Verlaufswerkzeug"
+
+#: src/gui/layerwidget.cc:147
+msgid "desaturate tool"
+msgstr "Entsättigen"
+
+#: src/gui/layerwidget.cc:148
+msgid "crop tool"
+msgstr "Freistellungswerkzeug"
+
+#: src/gui/layerwidget.cc:150
+msgid "clone stamp tool"
+msgstr "Klonstempel"
+
+#: src/gui/layerwidget.cc:152
+msgid "scale/rotate tool"
+msgstr "Skalieren-und-Rotieren-Werkzeug"
+
+#: src/gui/layerwidget.cc:153
+msgid "path tool"
+msgstr "Pfadwerkzeug"
+
+#: src/gui/layerwidget.cc:177
+msgid "Layers"
+msgstr "Ebenen"
+
+#: src/gui/layerwidget.cc:188
+msgid "Add a new layer"
+msgstr "Neue Ebene hinzufügen"
+
+#: src/gui/layerwidget.cc:190
+msgid "Add a new layer group"
+msgstr "Neue Ebenengruppe hinzufügen"
+
+#: src/gui/layerwidget.cc:192
+msgid "Remove selected layers"
+msgstr "Ausgewählte Ebenen entfernen"
+
+#: src/gui/layerwidget.cc:194
+msgid "Load an existing preset"
+msgstr "Eine Voreinstellung laden"
+
+#: src/gui/layerwidget.cc:196
+msgid "Save the selected layers as a preset"
+msgstr "Die ausgewählten Ebenen als Voreinstellung speichern"
+
+#: src/gui/layerwidget.cc:994
+msgid "New Group Layer"
+msgstr "Neue Ebenengruppe"
+
+#: src/gui/layerwidget.cc:1004
+msgid "Group Layer Config"
+msgstr "Ebenengruppenkonfiguration"
+
+#: src/gui/layerwidget.cc:1034 src/gui/layerwidget.cc:1039
+#: src/gui/layerwidget.cc:1102 src/gui/layerwidget.cc:1107
+msgid "Photoflow presets"
+msgstr "Photoflow-Voreinstellungen"
+
+#: src/gui/layerwidget.cc:1092
+msgid "Save preset as..."
+msgstr "Voreinstellung speichern unter..."
+
+#: src/gui/widgets/outmode_slider.cc:60
+msgid "preserve colors"
+msgstr "Farben erhalten"
+
+#: src/gui/mainwindow.cc:79
+msgid "files"
+msgstr "Dateien"
+
+#: src/gui/mainwindow.cc:80
+msgid "editing"
+msgstr "Bearbeite"
+
+#: src/gui/mainwindow.cc:101
+msgid "New Group"
+msgstr "Neue Ebenengruppe"
+
+#: src/gui/mainwindow.cc:137 src/gui/mainwindow.cc:161
+#: src/gui/mainwindow.cc:164
+msgid "Open existing file"
+msgstr "Vorhandene Datei öffnen"
+
+#: src/gui/mainwindow.cc:139
+msgid "Save current image"
+msgstr "Bild speichern"
+
+#: src/gui/mainwindow.cc:141
+msgid "Save current image with a different name"
+msgstr "Bild unter anderem Namen speichern"
+
+#: src/gui/mainwindow.cc:143
+msgid "Export current image to raster format"
+msgstr "Aktuelles Bild in ein Rasterformat exportieren"
+
+#: src/gui/mainwindow.cc:145
+msgid "Open settings dialog"
+msgstr "Einstellungen-Dialog öffnen"
+
+#: src/gui/mainwindow.cc:147
+msgid "Exit PhotoFlow"
+msgstr "PhotoFlow beenden"
+
+#: src/gui/mainwindow.cc:266
+msgid "Export"
+msgstr "Exportieren"
+
+#: src/gui/mainwindow.cc:567 src/gui/mainwindow.cc:625
+msgid "Image files"
+msgstr "Bilddateien"
+
+#: src/gui/mainwindow.cc:620 src/gui/mainwindow.cc:678
+msgid "All files"
+msgstr "Alle Dateien"
+
+#: src/gui/mainwindow.cc:750
+msgid "Save image as..."
+msgstr "Bild speichern unter..."
+
+#: src/gui/mainwindow.cc:766 src/gui/mainwindow.cc:771
+msgid "Photoflow files"
+msgstr "Photoflow-Dateien"
+
+#: src/gui/mainwindow.cc:853
+msgid "Export image as..."
+msgstr "Bild exportieren als..."
+
+#: src/gui/mainwindow.cc:863 src/gui/mainwindow.cc:868
+msgid "JPEG files"
+msgstr "JPEG-Dateien"
+
+#: src/gui/mainwindow.cc:875 src/gui/mainwindow.cc:880
+msgid "TIFF files"
+msgstr "TIFF-Dateien"
+
+#: src/gui/mainwindow.cc:981
+#, c-format
+msgid ""
+"Image \"%s\" contains unsaved data. Do you want to save it before closing?"
+msgstr ""
+"Das Bild \"%s\" enthält ungesicherte Änderungen. Möchten Sie diese vor dem "
+"Beenden speichern?"
+
+#~ msgid "Load"
+#~ msgstr "Laden"
+
+#~ msgid "Save"
+#~ msgstr "Speichern"
+
+#~ msgid "Open"
+#~ msgstr "ffnen"
+
+#~ msgid "Save as"
+#~ msgstr "Speichern unter"
+
+#~ msgid "Exit"
+#~ msgstr "Beenden"
+
+#~ msgid "feather radius"
+#~ msgstr "Ausblenderadius"
+
+#~ msgid "Extract Foreground"
+#~ msgstr "Vordergrund freistellen"
+
+#~ msgid "Iain's Noise Reduction"
+#~ msgstr "Rauschreduzierung (Iain)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Version 0.72\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-25 21:09+0200\n"
+"POT-Creation-Date: 2016-09-06 18:12+0200\n"
 "PO-Revision-Date: 2016-08-26 16:09+0100\n"
 "Last-Translator: Patrick Depoix <patrick.depoix@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,7 +56,8 @@ msgstr "découpage"
 msgid "curves"
 msgstr "courbes"
 
-#: src/operations/desaturate.cc:37
+#: src/operations/desaturate.cc:37 src/base/pftypes.cc:70
+#: src/base/pftypes.cc:79
 msgid "Luminosity"
 msgstr "Luminosité"
 
@@ -77,7 +78,7 @@ msgid "desaturate"
 msgstr "désaturation"
 
 #: src/operations/draw.cc:67 src/operations/draw.cc:69
-#: src/gui/layerwidget.cc:152
+#: src/gui/layerwidget.cc:152 src/gui/layerwidget.cc:151
 msgid "freehand drawing"
 msgstr "dessin main levée"
 
@@ -116,6 +117,7 @@ msgid "sharpening"
 msgstr "accentuation"
 
 #: src/operations/uniform.cc:49 src/gui/layerwidget.cc:148
+#: src/gui/layerwidget.cc:147
 msgid "uniform fill"
 msgstr "Remplissage uniforme"
 
@@ -140,14 +142,17 @@ msgid "exporting"
 msgstr "exportation"
 
 #: src/gui/imageeditor.cc:138 src/gui/imageeditor.cc:141
+#: src/gui/imageeditor.cc:142
 msgid "show merged layers"
 msgstr "affiche les calques fusionnés"
 
 #: src/gui/imageeditor.cc:139 src/gui/imageeditor.cc:142
+#: src/gui/imageeditor.cc:143
 msgid "show active layer"
 msgstr "affiche le calque actif"
 
 #: src/gui/imageeditor.cc:424 src/gui/imageeditor.cc:481
+#: src/gui/imageeditor.cc:485
 #, c-format
 msgid "Crash recovery found for file \"%s\". Do you want to restore it?"
 msgstr ""
@@ -163,35 +168,43 @@ msgid "Save"
 msgstr "Enregistrer"
 
 #: src/gui/layerwidget.cc:115 src/gui/layerwidget.cc:181
+#: src/gui/layerwidget.cc:180
 msgid "Layers"
 msgstr "Calques"
 
 #: src/gui/layerwidget.cc:123 src/gui/layerwidget.cc:192
+#: src/gui/layerwidget.cc:191
 msgid "Add a new layer"
 msgstr "Ajoutez un nouveau calque"
 
 #: src/gui/layerwidget.cc:125 src/gui/layerwidget.cc:194
+#: src/gui/layerwidget.cc:193
 msgid "Add a new layer group"
 msgstr "Ajoutez un nouveau groupe de calques"
 
 #: src/gui/layerwidget.cc:127 src/gui/layerwidget.cc:196
+#: src/gui/layerwidget.cc:195
 msgid "Remove selected layers"
 msgstr "Enlevez les calques sélectionnés"
 
 #: src/gui/layerwidget.cc:129 src/gui/layerwidget.cc:198
+#: src/gui/layerwidget.cc:197
 msgid "Load an existing preset"
 msgstr "Chargez un préréglage existant"
 
 #: src/gui/layerwidget.cc:130 src/gui/layerwidget.cc:200
+#: src/gui/layerwidget.cc:199
 msgid "Save the selected layers as a preset"
 msgstr "Enregistrez les calques sélectionnés en tant que préréglage"
 
 #: src/gui/layerwidget.cc:861 src/gui/layerwidget.cc:1250
+#: src/gui/layerwidget.cc:1249
 msgid "New Group Layer"
 msgstr "Nouveau groupe de calques"
 
 #: src/gui/layerwidget.cc:871 src/gui/layerwidget.cc:986
-#: src/gui/layerwidget.cc:1260
+#: src/gui/layerwidget.cc:1260 src/gui/layerwidget.cc:985
+#: src/gui/layerwidget.cc:1259
 msgid "Group Layer Config"
 msgstr "Configuration de groupe de calques"
 
@@ -199,10 +212,13 @@ msgstr "Configuration de groupe de calques"
 #: src/gui/layerwidget.cc:969 src/gui/layerwidget.cc:974
 #: src/gui/layerwidget.cc:1290 src/gui/layerwidget.cc:1295
 #: src/gui/layerwidget.cc:1362 src/gui/layerwidget.cc:1367
+#: src/gui/layerwidget.cc:1289 src/gui/layerwidget.cc:1294
+#: src/gui/layerwidget.cc:1361 src/gui/layerwidget.cc:1366
 msgid "Photoflow presets"
 msgstr "Préréglage Photoflow"
 
 #: src/gui/layerwidget.cc:959 src/gui/layerwidget.cc:1352
+#: src/gui/layerwidget.cc:1351
 msgid "Save preset as..."
 msgstr "Enregistrez le préréglage sous..."
 
@@ -224,18 +240,21 @@ msgstr "Fermer"
 
 #: src/gui/mainwindow.cc:359 src/gui/operationstree.cc:295
 #: src/gui/layerwidget.cc:683 src/gui/mainwindow.cc:552
+#: src/gui/layerwidget.cc:682
 msgid "Open image"
 msgstr "Ouvrir une image"
 
 #: src/gui/mainwindow.cc:374 src/gui/mainwindow.cc:385
 #: src/gui/layerwidget.cc:706 src/gui/layerwidget.cc:765
 #: src/gui/mainwindow.cc:567 src/gui/mainwindow.cc:625
+#: src/gui/layerwidget.cc:705 src/gui/layerwidget.cc:764
 msgid "Image files"
 msgstr "Fichiers images"
 
 #: src/gui/mainwindow.cc:380 src/gui/mainwindow.cc:391
 #: src/gui/layerwidget.cc:760 src/gui/layerwidget.cc:819
 #: src/gui/mainwindow.cc:620 src/gui/mainwindow.cc:678
+#: src/gui/layerwidget.cc:759 src/gui/layerwidget.cc:818
 msgid "All files"
 msgstr "Tous les fichiers"
 
@@ -272,16 +291,19 @@ msgstr ""
 
 #: src/gui/operation_config_gui.cc:79 src/gui/operation_config_gui.cc:80
 #: src/gui/operation_config_gui.cc:86 src/gui/operation_config_gui.cc:87
+#: src/gui/operation_config_gui.cc:88
 msgid "Intensity"
 msgstr "Intensité"
 
 #: src/gui/operation_config_gui.cc:81 src/gui/operation_config_gui.cc:82
 #: src/gui/operation_config_gui.cc:88 src/gui/operation_config_gui.cc:89
+#: src/gui/operation_config_gui.cc:90
 msgid "Opacity"
 msgstr "Opacité"
 
 #: src/gui/operation_config_gui.cc:83 src/gui/operation_config_gui.cc:84
 #: src/gui/operation_config_gui.cc:90 src/gui/operation_config_gui.cc:91
+#: src/gui/operation_config_gui.cc:92
 msgid "Enable mask"
 msgstr "Activez le masque"
 
@@ -296,14 +318,17 @@ msgstr "décalage Y"
 #: src/gui/operation_config_gui.cc:88 src/gui/operation_config_gui.cc:89
 #: src/gui/operation_config_gui.cc:90 src/gui/operation_config_gui.cc:95
 #: src/gui/operation_config_gui.cc:96 src/gui/operation_config_gui.cc:97
+#: src/gui/operation_config_gui.cc:98
 msgid "Target channel: "
 msgstr "Canal cible:"
 
 #: src/gui/operation_config_gui.cc:91 src/gui/operation_config_gui.cc:98
+#: src/gui/operation_config_gui.cc:99
 msgid "Target channel:"
 msgstr "Canal cible:"
 
 #: src/gui/operation_config_gui.cc:92 src/gui/operation_config_gui.cc:99
+#: src/gui/operation_config_gui.cc:100
 msgid "preview"
 msgstr "prévisualisation"
 
@@ -355,11 +380,13 @@ msgstr "Nom du calque:"
 
 #: src/gui/operations/hue_saturation_config.cc:85
 #: src/gui/operations/hue_saturation_config.cc:87
+#: src/gui/operations/brightness_contrast_config.cc:41
 msgid "Brightness"
 msgstr "Brillance"
 
 #: src/gui/operations/hue_saturation_config.cc:87
 #: src/gui/operations/hue_saturation_config.cc:89
+#: src/gui/operations/brightness_contrast_config.cc:42
 msgid "Contrast"
 msgstr "Contraste"
 
@@ -445,7 +472,7 @@ msgid "Curves"
 msgstr "Courbes"
 
 #: src/gui/operationstree.cc:307 src/gui/operationstree.cc:362
-#: src/gui/operationstree.cc:369
+#: src/gui/operationstree.cc:369 src/gui/operations/gradient_config.cc:48
 msgid "Invert"
 msgstr "Inverser"
 
@@ -714,6 +741,7 @@ msgid "path mask"
 msgstr "Masque de chemin"
 
 #: src/operations/perspective.cc:51 src/gui/layerwidget.cc:154
+#: src/gui/layerwidget.cc:153
 msgid "perspective correction"
 msgstr "correction de perspective"
 
@@ -737,95 +765,96 @@ msgstr "ombres/éclats"
 msgid "updating"
 msgstr "mise à jour"
 
-#: src/gui/imageeditor.cc:191
+#: src/gui/imageeditor.cc:191 src/gui/imageeditor.cc:192
 msgid "Toggle highlights clipping warning on/off"
 msgstr "Activer/désactiver l'alarme de réduction d'éclats"
 
-#: src/gui/imageeditor.cc:195
+#: src/gui/imageeditor.cc:195 src/gui/imageeditor.cc:196
 msgid "Toggle shadows clipping warning on/off"
 msgstr "Activer/désactiver l'alarme de réduction d'ombres"
 
-#: src/gui/imageeditor.cc:201
+#: src/gui/imageeditor.cc:201 src/gui/imageeditor.cc:202
 msgid "Zoom to 100%"
 msgstr "zoom à 100%"
 
-#: src/gui/imageeditor.cc:205
+#: src/gui/imageeditor.cc:205 src/gui/imageeditor.cc:206
 msgid "Fit image to preview area"
 msgstr "ajuster l'image à la prévisualisation"
 
-#: src/gui/imageeditor.cc:209
+#: src/gui/imageeditor.cc:209 src/gui/imageeditor.cc:210
 msgid "Zoom out"
 msgstr "zoom arrière"
 
-#: src/gui/imageeditor.cc:213
+#: src/gui/imageeditor.cc:213 src/gui/imageeditor.cc:214
 msgid "Zoom in"
 msgstr "zoom avant"
 
-#: src/gui/imageeditor.cc:222
+#: src/gui/imageeditor.cc:222 src/gui/imageeditor.cc:223
 msgid "histogram"
 msgstr "histogramme"
 
 #: src/gui/layerwidget.cc:116 src/gui/mainwindow.cc:100
+#: src/gui/layerwidget.cc:115
 msgid "New Adjustment"
 msgstr "Nouvel ajustement"
 
-#: src/gui/layerwidget.cc:119
+#: src/gui/layerwidget.cc:119 src/gui/layerwidget.cc:118
 msgid "Load preset"
 msgstr "Chargez un préréglage"
 
-#: src/gui/layerwidget.cc:120
+#: src/gui/layerwidget.cc:120 src/gui/layerwidget.cc:119
 msgid "Save preset"
 msgstr "Enregistrez le préréglage"
 
-#: src/gui/layerwidget.cc:142
+#: src/gui/layerwidget.cc:142 src/gui/layerwidget.cc:141
 msgid "new layer"
 msgstr "Ajoutez un nouveau calque"
 
-#: src/gui/layerwidget.cc:143
+#: src/gui/layerwidget.cc:143 src/gui/layerwidget.cc:142
 msgid "new group layer"
 msgstr "nouveau groupe de calques "
 
-#: src/gui/layerwidget.cc:144
+#: src/gui/layerwidget.cc:144 src/gui/layerwidget.cc:143
 msgid "delete layer"
 msgstr "Enlevez le calque sélectionné"
 
-#: src/gui/layerwidget.cc:145
+#: src/gui/layerwidget.cc:145 src/gui/layerwidget.cc:144
 msgid "insert image as layer"
 msgstr "in-serrer une image en calque"
 
-#: src/gui/layerwidget.cc:146
+#: src/gui/layerwidget.cc:146 src/gui/layerwidget.cc:145
 msgid "basic editing"
 msgstr "Edition basique"
 
-#: src/gui/layerwidget.cc:147
+#: src/gui/layerwidget.cc:147 src/gui/layerwidget.cc:146
 msgid "curves tool"
 msgstr "outil courbe"
 
-#: src/gui/layerwidget.cc:149
+#: src/gui/layerwidget.cc:149 src/gui/layerwidget.cc:148
 msgid "gradient tool"
 msgstr "outil dégradé"
 
-#: src/gui/layerwidget.cc:150
+#: src/gui/layerwidget.cc:150 src/gui/layerwidget.cc:149
 msgid "desaturate tool"
 msgstr "outil désaturation"
 
-#: src/gui/layerwidget.cc:151
+#: src/gui/layerwidget.cc:151 src/gui/layerwidget.cc:150
 msgid "crop tool"
 msgstr "outil de découpe"
 
-#: src/gui/layerwidget.cc:153
+#: src/gui/layerwidget.cc:153 src/gui/layerwidget.cc:152
 msgid "clone stamp tool"
 msgstr "Outil clonage"
 
-#: src/gui/layerwidget.cc:155
+#: src/gui/layerwidget.cc:155 src/gui/layerwidget.cc:154
 msgid "scale/rotate tool"
 msgstr "outil échelle/rotation"
 
-#: src/gui/layerwidget.cc:156
+#: src/gui/layerwidget.cc:156 src/gui/layerwidget.cc:155
 msgid "path tool"
 msgstr "outil chemin"
 
-#: src/gui/layerwidget.cc:976
+#: src/gui/layerwidget.cc:976 src/gui/layerwidget.cc:975
 msgid "RAW image"
 msgstr "Ouvrir une image"
 
@@ -866,39 +895,43 @@ msgstr "Ouvrir la fenêtre des réglages"
 msgid "Exit PhotoFlow"
 msgstr "Fermer PhotofFow"
 
-#: src/gui/operation_config_gui.cc:92
+#: src/gui/operation_config_gui.cc:92 src/gui/operation_config_gui.cc:93
 msgid "X shift "
 msgstr "décalage X"
 
-#: src/gui/operation_config_gui.cc:93
+#: src/gui/operation_config_gui.cc:93 src/gui/operation_config_gui.cc:94
 msgid "Y shift "
 msgstr "décalage Y"
 
-#: src/gui/operation_config_gui.cc:253
+#: src/gui/operation_config_gui.cc:253 src/gui/operation_config_gui.cc:254
 msgid "toggle layer visibility on/off"
 msgstr "Activer/désactiver la visibilité des calques"
 
 #: src/gui/operation_config_gui.cc:254 src/gui/operation_config_gui.cc:255
+#: src/gui/operation_config_gui.cc:256
 msgid "enable/disable layer mask(s)"
 msgstr "activer/désactiver le masque(s) de calque"
 
 #: src/gui/operation_config_gui.cc:256 src/gui/operation_config_gui.cc:257
+#: src/gui/operation_config_gui.cc:258
 msgid "toggle sticky flag on/off"
 msgstr "Activer/désactiver le \"favoris\""
 
 #: src/gui/operation_config_gui.cc:258 src/gui/operation_config_gui.cc:259
+#: src/gui/operation_config_gui.cc:260
 msgid "toggle editing flag on/off"
 msgstr "activer/désactiver l'état d'édition"
 
-#: src/gui/operation_config_gui.cc:260
+#: src/gui/operation_config_gui.cc:260 src/gui/operation_config_gui.cc:261
 msgid "reset tool parameters"
 msgstr "restaurer les paramètres de l'outil"
 
 #: src/gui/operation_config_gui.cc:261 src/gui/operation_config_gui.cc:262
+#: src/gui/operation_config_gui.cc:263
 msgid "show information on current tool"
 msgstr "afficher l'information sur l'outil"
 
-#: src/gui/operation_config_gui.cc:707
+#: src/gui/operation_config_gui.cc:707 src/gui/operation_config_gui.cc:708
 msgid "Close"
 msgstr "Fermer"
 
@@ -1166,3 +1199,253 @@ msgstr "Afficher le type de profil:"
 #: src/gui/widgets/outmode_slider.cc:60
 msgid "preserve colors"
 msgstr "préserver les couleurs"
+
+#: src/base/image.cc:688
+msgid "background"
+msgstr ""
+
+#: src/base/pftypes.cc:56 src/base/pftypes.cc:65
+msgid "Passthrough"
+msgstr ""
+
+#: src/base/pftypes.cc:57 src/base/pftypes.cc:66
+msgid "Normal"
+msgstr ""
+
+#: src/base/pftypes.cc:59 src/base/pftypes.cc:68
+msgid "Grain extract"
+msgstr ""
+
+#: src/base/pftypes.cc:60 src/base/pftypes.cc:69
+msgid "Grain merge"
+msgstr ""
+
+#: src/base/pftypes.cc:61 src/base/pftypes.cc:70
+msgid "Overlay"
+msgstr ""
+
+#: src/base/pftypes.cc:63 src/base/pftypes.cc:72
+msgid "Soft light"
+msgstr ""
+
+#: src/base/pftypes.cc:64 src/base/pftypes.cc:73
+msgid "Hard light"
+msgstr ""
+
+#: src/base/pftypes.cc:65 src/base/pftypes.cc:74
+msgid "Vivid light"
+msgstr ""
+
+#: src/base/pftypes.cc:66 src/base/pftypes.cc:75
+msgid "Multiply"
+msgstr ""
+
+#: src/base/pftypes.cc:67 src/base/pftypes.cc:76
+#, fuzzy
+msgid "Screen"
+msgstr "vert"
+
+#: src/base/pftypes.cc:68 src/base/pftypes.cc:77
+#, fuzzy
+msgid "Lighten"
+msgstr "clarté"
+
+#: src/base/pftypes.cc:69 src/base/pftypes.cc:78
+msgid "Darken"
+msgstr ""
+
+#: src/base/pftypes.cc:71 src/base/pftypes.cc:80
+msgid "Color"
+msgstr ""
+
+#: src/gui/settingsdialog.cc:67
+msgid "Color management"
+msgstr ""
+
+#: src/gui/settingsdialog.cc:68
+msgid "About"
+msgstr ""
+
+#: src/gui/settingsdialog.cc:212
+msgid "Please choose an ICC profile"
+msgstr ""
+
+#: src/operations/scale.cc:199
+msgid "Fit"
+msgstr ""
+
+#: src/operations/scale.cc:200
+msgid "percent"
+msgstr ""
+
+#: src/operations/scale.cc:217
+msgid "pixels"
+msgstr ""
+
+#: src/operations/scale.cc:218
+msgid "mm"
+msgstr ""
+
+#: src/operations/scale.cc:219
+msgid "cm"
+msgstr ""
+
+#: src/operations/scale.cc:220
+msgid "inches"
+msgstr ""
+
+#: src/gui/operations/clone_config.cc:38
+#, fuzzy
+msgid "Source channel: "
+msgstr "Canal cible:"
+
+#: src/gui/operations/clone_stamp_config.cc:38
+msgid "Stamp size: "
+msgstr ""
+
+#: src/gui/operations/clone_stamp_config.cc:39
+msgid "Stamp opacity: "
+msgstr ""
+
+#: src/gui/operations/clone_stamp_config.cc:40
+msgid "Stamp smoothness: "
+msgstr ""
+
+#: src/gui/operations/clone_stamp_config.cc:41
+#: src/gui/operations/draw_config.cc:52
+msgid "Undo"
+msgstr ""
+
+#: src/gui/operations/uniform_config.cc:38
+msgid "Color:              "
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:46
+#, fuzzy
+msgid "Gradient tool"
+msgstr "outil dégradé"
+
+#: src/gui/operations/gradient_config.cc:47
+msgid "Type:) "
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:49
+msgid "Center X (%)"
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:50
+msgid "Center Y (%))"
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:38
+#, fuzzy
+msgid "Crop left"
+msgstr "Ouvrir une image"
+
+#: src/gui/operations/crop_config.cc:39
+#, fuzzy
+msgid "Crop top"
+msgstr "outil de découpe"
+
+#: src/gui/operations/crop_config.cc:40
+#, fuzzy
+msgid "Crop width"
+msgstr "Ouvrir une image"
+
+#: src/gui/operations/crop_config.cc:41
+#, fuzzy
+msgid "Crop height"
+msgstr "Ouvrir une image"
+
+#: src/gui/operations/crop_config.cc:42
+msgid "Keep aspect ratio"
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:43
+msgid "Aspect ratio: W="
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:44
+msgid "/H="
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:47
+msgid "Type: "
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:50
+msgid "Center Y (%)"
+msgstr ""
+
+#: src/gui/operations/desaturate_config.cc:35
+#, fuzzy
+msgid "Desaturate method: "
+msgstr "outil désaturation"
+
+#: src/gui/operations/draw_config.cc:38
+msgid "Pen color:              "
+msgstr ""
+
+#: src/gui/operations/draw_config.cc:39
+msgid "Background color: "
+msgstr ""
+
+#: src/gui/operations/draw_config.cc:49
+msgid "Pen size: "
+msgstr ""
+
+#: src/gui/operations/draw_config.cc:50
+#, fuzzy
+msgid "Pen opacity: "
+msgstr "Opacité"
+
+#: src/gui/operations/draw_config.cc:51
+msgid "pen smoothness: "
+msgstr ""
+
+#: src/gui/operationstree.cc:208 src/gui/operation_config_gui.cc:688
+#: src/gui/operation_config_gui.cc:689
+msgid "This help is not yet available. Sorry."
+msgstr ""
+
+#: src/gui/layerwidget.cc:497 src/gui/layerwidget.cc:496
+#, fuzzy
+msgid "opacity ("
+msgstr "Opacité"
+
+#: src/gui/settingsdialog.cc:89
+msgid "Custom"
+msgstr ""
+
+#: src/gui/layerwidget.cc:1280 src/gui/layerwidget.cc:1279
+#, fuzzy
+msgid "Open preset"
+msgstr "Enregistrez le préréglage"
+
+#: src/gui/widgets/curveeditor.cc:42
+msgid "in: "
+msgstr ""
+
+#: src/gui/widgets/curveeditor.cc:43
+#, fuzzy
+msgid "out: "
+msgstr "entrée:"
+
+#: src/gui/operations/curves_config.cc:51
+#: src/gui/operations/brightness_contrast_config.cc:43
+msgid "Output mode"
+msgstr ""
+
+#: src/gui/operation_config_gui.cc:669 src/gui/operation_config_gui.cc:670
+msgid "help"
+msgstr ""
+
+#: src/gui/layerwidget.cc:449 src/gui/layerwidget.cc:448
+#, fuzzy
+msgid "intensity ("
+msgstr "Intensité"
+
+#: src/gui/layerwidget.cc:964 src/gui/layerwidget.cc:963
+#, fuzzy
+msgid "image file"
+msgstr "Fichiers images"

--- a/po/photoflow.pot
+++ b/po/photoflow.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-25 21:09+0200\n"
+"POT-Creation-Date: 2016-09-06 18:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -55,7 +55,8 @@ msgstr ""
 msgid "curves"
 msgstr ""
 
-#: src/operations/desaturate.cc:37
+#: src/operations/desaturate.cc:37 src/base/pftypes.cc:70
+#: src/base/pftypes.cc:79
 msgid "Luminosity"
 msgstr ""
 
@@ -76,7 +77,7 @@ msgid "desaturate"
 msgstr ""
 
 #: src/operations/draw.cc:67 src/operations/draw.cc:69
-#: src/gui/layerwidget.cc:152
+#: src/gui/layerwidget.cc:152 src/gui/layerwidget.cc:151
 msgid "freehand drawing"
 msgstr ""
 
@@ -115,6 +116,7 @@ msgid "sharpening"
 msgstr ""
 
 #: src/operations/uniform.cc:49 src/gui/layerwidget.cc:148
+#: src/gui/layerwidget.cc:147
 msgid "uniform fill"
 msgstr ""
 
@@ -139,14 +141,17 @@ msgid "exporting"
 msgstr ""
 
 #: src/gui/imageeditor.cc:138 src/gui/imageeditor.cc:141
+#: src/gui/imageeditor.cc:142
 msgid "show merged layers"
 msgstr ""
 
 #: src/gui/imageeditor.cc:139 src/gui/imageeditor.cc:142
+#: src/gui/imageeditor.cc:143
 msgid "show active layer"
 msgstr ""
 
 #: src/gui/imageeditor.cc:424 src/gui/imageeditor.cc:481
+#: src/gui/imageeditor.cc:485
 #, c-format
 msgid "Crash recovery found for file \"%s\". Do you want to restore it?"
 msgstr ""
@@ -160,35 +165,43 @@ msgid "Save"
 msgstr ""
 
 #: src/gui/layerwidget.cc:115 src/gui/layerwidget.cc:181
+#: src/gui/layerwidget.cc:180
 msgid "Layers"
 msgstr ""
 
 #: src/gui/layerwidget.cc:123 src/gui/layerwidget.cc:192
+#: src/gui/layerwidget.cc:191
 msgid "Add a new layer"
 msgstr ""
 
 #: src/gui/layerwidget.cc:125 src/gui/layerwidget.cc:194
+#: src/gui/layerwidget.cc:193
 msgid "Add a new layer group"
 msgstr ""
 
 #: src/gui/layerwidget.cc:127 src/gui/layerwidget.cc:196
+#: src/gui/layerwidget.cc:195
 msgid "Remove selected layers"
 msgstr ""
 
 #: src/gui/layerwidget.cc:129 src/gui/layerwidget.cc:198
+#: src/gui/layerwidget.cc:197
 msgid "Load an existing preset"
 msgstr ""
 
 #: src/gui/layerwidget.cc:130 src/gui/layerwidget.cc:200
+#: src/gui/layerwidget.cc:199
 msgid "Save the selected layers as a preset"
 msgstr ""
 
 #: src/gui/layerwidget.cc:861 src/gui/layerwidget.cc:1250
+#: src/gui/layerwidget.cc:1249
 msgid "New Group Layer"
 msgstr ""
 
 #: src/gui/layerwidget.cc:871 src/gui/layerwidget.cc:986
-#: src/gui/layerwidget.cc:1260
+#: src/gui/layerwidget.cc:1260 src/gui/layerwidget.cc:985
+#: src/gui/layerwidget.cc:1259
 msgid "Group Layer Config"
 msgstr ""
 
@@ -196,10 +209,13 @@ msgstr ""
 #: src/gui/layerwidget.cc:969 src/gui/layerwidget.cc:974
 #: src/gui/layerwidget.cc:1290 src/gui/layerwidget.cc:1295
 #: src/gui/layerwidget.cc:1362 src/gui/layerwidget.cc:1367
+#: src/gui/layerwidget.cc:1289 src/gui/layerwidget.cc:1294
+#: src/gui/layerwidget.cc:1361 src/gui/layerwidget.cc:1366
 msgid "Photoflow presets"
 msgstr ""
 
 #: src/gui/layerwidget.cc:959 src/gui/layerwidget.cc:1352
+#: src/gui/layerwidget.cc:1351
 msgid "Save preset as..."
 msgstr ""
 
@@ -221,18 +237,21 @@ msgstr ""
 
 #: src/gui/mainwindow.cc:359 src/gui/operationstree.cc:295
 #: src/gui/layerwidget.cc:683 src/gui/mainwindow.cc:552
+#: src/gui/layerwidget.cc:682
 msgid "Open image"
 msgstr ""
 
 #: src/gui/mainwindow.cc:374 src/gui/mainwindow.cc:385
 #: src/gui/layerwidget.cc:706 src/gui/layerwidget.cc:765
 #: src/gui/mainwindow.cc:567 src/gui/mainwindow.cc:625
+#: src/gui/layerwidget.cc:705 src/gui/layerwidget.cc:764
 msgid "Image files"
 msgstr ""
 
 #: src/gui/mainwindow.cc:380 src/gui/mainwindow.cc:391
 #: src/gui/layerwidget.cc:760 src/gui/layerwidget.cc:819
 #: src/gui/mainwindow.cc:620 src/gui/mainwindow.cc:678
+#: src/gui/layerwidget.cc:759 src/gui/layerwidget.cc:818
 msgid "All files"
 msgstr ""
 
@@ -267,16 +286,19 @@ msgstr ""
 
 #: src/gui/operation_config_gui.cc:79 src/gui/operation_config_gui.cc:80
 #: src/gui/operation_config_gui.cc:86 src/gui/operation_config_gui.cc:87
+#: src/gui/operation_config_gui.cc:88
 msgid "Intensity"
 msgstr ""
 
 #: src/gui/operation_config_gui.cc:81 src/gui/operation_config_gui.cc:82
 #: src/gui/operation_config_gui.cc:88 src/gui/operation_config_gui.cc:89
+#: src/gui/operation_config_gui.cc:90
 msgid "Opacity"
 msgstr ""
 
 #: src/gui/operation_config_gui.cc:83 src/gui/operation_config_gui.cc:84
 #: src/gui/operation_config_gui.cc:90 src/gui/operation_config_gui.cc:91
+#: src/gui/operation_config_gui.cc:92
 msgid "Enable mask"
 msgstr ""
 
@@ -291,14 +313,17 @@ msgstr ""
 #: src/gui/operation_config_gui.cc:88 src/gui/operation_config_gui.cc:89
 #: src/gui/operation_config_gui.cc:90 src/gui/operation_config_gui.cc:95
 #: src/gui/operation_config_gui.cc:96 src/gui/operation_config_gui.cc:97
+#: src/gui/operation_config_gui.cc:98
 msgid "Target channel: "
 msgstr ""
 
 #: src/gui/operation_config_gui.cc:91 src/gui/operation_config_gui.cc:98
+#: src/gui/operation_config_gui.cc:99
 msgid "Target channel:"
 msgstr ""
 
 #: src/gui/operation_config_gui.cc:92 src/gui/operation_config_gui.cc:99
+#: src/gui/operation_config_gui.cc:100
 msgid "preview"
 msgstr ""
 
@@ -350,11 +375,13 @@ msgstr ""
 
 #: src/gui/operations/hue_saturation_config.cc:85
 #: src/gui/operations/hue_saturation_config.cc:87
+#: src/gui/operations/brightness_contrast_config.cc:41
 msgid "Brightness"
 msgstr ""
 
 #: src/gui/operations/hue_saturation_config.cc:87
 #: src/gui/operations/hue_saturation_config.cc:89
+#: src/gui/operations/brightness_contrast_config.cc:42
 msgid "Contrast"
 msgstr ""
 
@@ -440,7 +467,7 @@ msgid "Curves"
 msgstr ""
 
 #: src/gui/operationstree.cc:307 src/gui/operationstree.cc:362
-#: src/gui/operationstree.cc:369
+#: src/gui/operationstree.cc:369 src/gui/operations/gradient_config.cc:48
 msgid "Invert"
 msgstr ""
 
@@ -709,6 +736,7 @@ msgid "path mask"
 msgstr ""
 
 #: src/operations/perspective.cc:51 src/gui/layerwidget.cc:154
+#: src/gui/layerwidget.cc:153
 msgid "perspective correction"
 msgstr ""
 
@@ -732,95 +760,96 @@ msgstr ""
 msgid "updating"
 msgstr ""
 
-#: src/gui/imageeditor.cc:191
+#: src/gui/imageeditor.cc:191 src/gui/imageeditor.cc:192
 msgid "Toggle highlights clipping warning on/off"
 msgstr ""
 
-#: src/gui/imageeditor.cc:195
+#: src/gui/imageeditor.cc:195 src/gui/imageeditor.cc:196
 msgid "Toggle shadows clipping warning on/off"
 msgstr ""
 
-#: src/gui/imageeditor.cc:201
+#: src/gui/imageeditor.cc:201 src/gui/imageeditor.cc:202
 msgid "Zoom to 100%"
 msgstr ""
 
-#: src/gui/imageeditor.cc:205
+#: src/gui/imageeditor.cc:205 src/gui/imageeditor.cc:206
 msgid "Fit image to preview area"
 msgstr ""
 
-#: src/gui/imageeditor.cc:209
+#: src/gui/imageeditor.cc:209 src/gui/imageeditor.cc:210
 msgid "Zoom out"
 msgstr ""
 
-#: src/gui/imageeditor.cc:213
+#: src/gui/imageeditor.cc:213 src/gui/imageeditor.cc:214
 msgid "Zoom in"
 msgstr ""
 
-#: src/gui/imageeditor.cc:222
+#: src/gui/imageeditor.cc:222 src/gui/imageeditor.cc:223
 msgid "histogram"
 msgstr ""
 
 #: src/gui/layerwidget.cc:116 src/gui/mainwindow.cc:100
+#: src/gui/layerwidget.cc:115
 msgid "New Adjustment"
 msgstr ""
 
-#: src/gui/layerwidget.cc:119
+#: src/gui/layerwidget.cc:119 src/gui/layerwidget.cc:118
 msgid "Load preset"
 msgstr ""
 
-#: src/gui/layerwidget.cc:120
+#: src/gui/layerwidget.cc:120 src/gui/layerwidget.cc:119
 msgid "Save preset"
 msgstr ""
 
-#: src/gui/layerwidget.cc:142
+#: src/gui/layerwidget.cc:142 src/gui/layerwidget.cc:141
 msgid "new layer"
 msgstr ""
 
-#: src/gui/layerwidget.cc:143
+#: src/gui/layerwidget.cc:143 src/gui/layerwidget.cc:142
 msgid "new group layer"
 msgstr ""
 
-#: src/gui/layerwidget.cc:144
+#: src/gui/layerwidget.cc:144 src/gui/layerwidget.cc:143
 msgid "delete layer"
 msgstr ""
 
-#: src/gui/layerwidget.cc:145
+#: src/gui/layerwidget.cc:145 src/gui/layerwidget.cc:144
 msgid "insert image as layer"
 msgstr ""
 
-#: src/gui/layerwidget.cc:146
+#: src/gui/layerwidget.cc:146 src/gui/layerwidget.cc:145
 msgid "basic editing"
 msgstr ""
 
-#: src/gui/layerwidget.cc:147
+#: src/gui/layerwidget.cc:147 src/gui/layerwidget.cc:146
 msgid "curves tool"
 msgstr ""
 
-#: src/gui/layerwidget.cc:149
+#: src/gui/layerwidget.cc:149 src/gui/layerwidget.cc:148
 msgid "gradient tool"
 msgstr ""
 
-#: src/gui/layerwidget.cc:150
+#: src/gui/layerwidget.cc:150 src/gui/layerwidget.cc:149
 msgid "desaturate tool"
 msgstr ""
 
-#: src/gui/layerwidget.cc:151
+#: src/gui/layerwidget.cc:151 src/gui/layerwidget.cc:150
 msgid "crop tool"
 msgstr ""
 
-#: src/gui/layerwidget.cc:153
+#: src/gui/layerwidget.cc:153 src/gui/layerwidget.cc:152
 msgid "clone stamp tool"
 msgstr ""
 
-#: src/gui/layerwidget.cc:155
+#: src/gui/layerwidget.cc:155 src/gui/layerwidget.cc:154
 msgid "scale/rotate tool"
 msgstr ""
 
-#: src/gui/layerwidget.cc:156
+#: src/gui/layerwidget.cc:156 src/gui/layerwidget.cc:155
 msgid "path tool"
 msgstr ""
 
-#: src/gui/layerwidget.cc:976
+#: src/gui/layerwidget.cc:976 src/gui/layerwidget.cc:975
 msgid "RAW image"
 msgstr ""
 
@@ -861,39 +890,43 @@ msgstr ""
 msgid "Exit PhotoFlow"
 msgstr ""
 
-#: src/gui/operation_config_gui.cc:92
+#: src/gui/operation_config_gui.cc:92 src/gui/operation_config_gui.cc:93
 msgid "X shift "
 msgstr ""
 
-#: src/gui/operation_config_gui.cc:93
+#: src/gui/operation_config_gui.cc:93 src/gui/operation_config_gui.cc:94
 msgid "Y shift "
 msgstr ""
 
-#: src/gui/operation_config_gui.cc:253
+#: src/gui/operation_config_gui.cc:253 src/gui/operation_config_gui.cc:254
 msgid "toggle layer visibility on/off"
 msgstr ""
 
 #: src/gui/operation_config_gui.cc:254 src/gui/operation_config_gui.cc:255
+#: src/gui/operation_config_gui.cc:256
 msgid "enable/disable layer mask(s)"
 msgstr ""
 
 #: src/gui/operation_config_gui.cc:256 src/gui/operation_config_gui.cc:257
+#: src/gui/operation_config_gui.cc:258
 msgid "toggle sticky flag on/off"
 msgstr ""
 
 #: src/gui/operation_config_gui.cc:258 src/gui/operation_config_gui.cc:259
+#: src/gui/operation_config_gui.cc:260
 msgid "toggle editing flag on/off"
 msgstr ""
 
-#: src/gui/operation_config_gui.cc:260
+#: src/gui/operation_config_gui.cc:260 src/gui/operation_config_gui.cc:261
 msgid "reset tool parameters"
 msgstr ""
 
 #: src/gui/operation_config_gui.cc:261 src/gui/operation_config_gui.cc:262
+#: src/gui/operation_config_gui.cc:263
 msgid "show information on current tool"
 msgstr ""
 
-#: src/gui/operation_config_gui.cc:707
+#: src/gui/operation_config_gui.cc:707 src/gui/operation_config_gui.cc:708
 msgid "Close"
 msgstr ""
 
@@ -1160,4 +1193,239 @@ msgstr ""
 
 #: src/gui/widgets/outmode_slider.cc:60
 msgid "preserve colors"
+msgstr ""
+
+#: src/base/image.cc:688
+msgid "background"
+msgstr ""
+
+#: src/base/pftypes.cc:56 src/base/pftypes.cc:65
+msgid "Passthrough"
+msgstr ""
+
+#: src/base/pftypes.cc:57 src/base/pftypes.cc:66
+msgid "Normal"
+msgstr ""
+
+#: src/base/pftypes.cc:59 src/base/pftypes.cc:68
+msgid "Grain extract"
+msgstr ""
+
+#: src/base/pftypes.cc:60 src/base/pftypes.cc:69
+msgid "Grain merge"
+msgstr ""
+
+#: src/base/pftypes.cc:61 src/base/pftypes.cc:70
+msgid "Overlay"
+msgstr ""
+
+#: src/base/pftypes.cc:63 src/base/pftypes.cc:72
+msgid "Soft light"
+msgstr ""
+
+#: src/base/pftypes.cc:64 src/base/pftypes.cc:73
+msgid "Hard light"
+msgstr ""
+
+#: src/base/pftypes.cc:65 src/base/pftypes.cc:74
+msgid "Vivid light"
+msgstr ""
+
+#: src/base/pftypes.cc:66 src/base/pftypes.cc:75
+msgid "Multiply"
+msgstr ""
+
+#: src/base/pftypes.cc:67 src/base/pftypes.cc:76
+msgid "Screen"
+msgstr ""
+
+#: src/base/pftypes.cc:68 src/base/pftypes.cc:77
+msgid "Lighten"
+msgstr ""
+
+#: src/base/pftypes.cc:69 src/base/pftypes.cc:78
+msgid "Darken"
+msgstr ""
+
+#: src/base/pftypes.cc:71 src/base/pftypes.cc:80
+msgid "Color"
+msgstr ""
+
+#: src/gui/settingsdialog.cc:67
+msgid "Color management"
+msgstr ""
+
+#: src/gui/settingsdialog.cc:68
+msgid "About"
+msgstr ""
+
+#: src/gui/settingsdialog.cc:212
+msgid "Please choose an ICC profile"
+msgstr ""
+
+#: src/operations/scale.cc:199
+msgid "Fit"
+msgstr ""
+
+#: src/operations/scale.cc:200
+msgid "percent"
+msgstr ""
+
+#: src/operations/scale.cc:217
+msgid "pixels"
+msgstr ""
+
+#: src/operations/scale.cc:218
+msgid "mm"
+msgstr ""
+
+#: src/operations/scale.cc:219
+msgid "cm"
+msgstr ""
+
+#: src/operations/scale.cc:220
+msgid "inches"
+msgstr ""
+
+#: src/gui/operations/clone_config.cc:38
+msgid "Source channel: "
+msgstr ""
+
+#: src/gui/operations/clone_stamp_config.cc:38
+msgid "Stamp size: "
+msgstr ""
+
+#: src/gui/operations/clone_stamp_config.cc:39
+msgid "Stamp opacity: "
+msgstr ""
+
+#: src/gui/operations/clone_stamp_config.cc:40
+msgid "Stamp smoothness: "
+msgstr ""
+
+#: src/gui/operations/clone_stamp_config.cc:41
+#: src/gui/operations/draw_config.cc:52
+msgid "Undo"
+msgstr ""
+
+#: src/gui/operations/uniform_config.cc:38
+msgid "Color:              "
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:46
+msgid "Gradient tool"
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:47
+msgid "Type:) "
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:49
+msgid "Center X (%)"
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:50
+msgid "Center Y (%))"
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:38
+msgid "Crop left"
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:39
+msgid "Crop top"
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:40
+msgid "Crop width"
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:41
+msgid "Crop height"
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:42
+msgid "Keep aspect ratio"
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:43
+msgid "Aspect ratio: W="
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:44
+msgid "/H="
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:47
+msgid "Type: "
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:50
+msgid "Center Y (%)"
+msgstr ""
+
+#: src/gui/operations/desaturate_config.cc:35
+msgid "Desaturate method: "
+msgstr ""
+
+#: src/gui/operations/draw_config.cc:38
+msgid "Pen color:              "
+msgstr ""
+
+#: src/gui/operations/draw_config.cc:39
+msgid "Background color: "
+msgstr ""
+
+#: src/gui/operations/draw_config.cc:49
+msgid "Pen size: "
+msgstr ""
+
+#: src/gui/operations/draw_config.cc:50
+msgid "Pen opacity: "
+msgstr ""
+
+#: src/gui/operations/draw_config.cc:51
+msgid "pen smoothness: "
+msgstr ""
+
+#: src/gui/operationstree.cc:208 src/gui/operation_config_gui.cc:688
+#: src/gui/operation_config_gui.cc:689
+msgid "This help is not yet available. Sorry."
+msgstr ""
+
+#: src/gui/layerwidget.cc:497 src/gui/layerwidget.cc:496
+msgid "opacity ("
+msgstr ""
+
+#: src/gui/settingsdialog.cc:89
+msgid "Custom"
+msgstr ""
+
+#: src/gui/layerwidget.cc:1280 src/gui/layerwidget.cc:1279
+msgid "Open preset"
+msgstr ""
+
+#: src/gui/widgets/curveeditor.cc:42
+msgid "in: "
+msgstr ""
+
+#: src/gui/widgets/curveeditor.cc:43
+msgid "out: "
+msgstr ""
+
+#: src/gui/operations/curves_config.cc:51
+#: src/gui/operations/brightness_contrast_config.cc:43
+msgid "Output mode"
+msgstr ""
+
+#: src/gui/operation_config_gui.cc:669 src/gui/operation_config_gui.cc:670
+msgid "help"
+msgstr ""
+
+#: src/gui/layerwidget.cc:449 src/gui/layerwidget.cc:448
+msgid "intensity ("
+msgstr ""
+
+#: src/gui/layerwidget.cc:964 src/gui/layerwidget.cc:963
+msgid "image file"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,12 +1,12 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-25 21:09+0200\n"
+"POT-Creation-Date: 2016-09-06 18:12+0200\n"
 "PO-Revision-Date: 2016-08-26 20:47+0200\n"
 "Last-Translator: Zbigniew Malach (Zbyma72age) <zbigniew.malach@gmail.com>\n"
 "Language-Team: \n"
@@ -56,7 +56,8 @@ msgstr "kadruj"
 msgid "curves"
 msgstr "krzywe"
 
-#: src/operations/desaturate.cc:37
+#: src/operations/desaturate.cc:37 src/base/pftypes.cc:70
+#: src/base/pftypes.cc:79
 msgid "Luminosity"
 msgstr "Luminancja"
 
@@ -77,7 +78,7 @@ msgid "desaturate"
 msgstr "desaturacja"
 
 #: src/operations/draw.cc:67 src/operations/draw.cc:69
-#: src/gui/layerwidget.cc:152
+#: src/gui/layerwidget.cc:152 src/gui/layerwidget.cc:151
 msgid "freehand drawing"
 msgstr "rysunek odręczny"
 
@@ -116,6 +117,7 @@ msgid "sharpening"
 msgstr "ostrzenie"
 
 #: src/operations/uniform.cc:49 src/gui/layerwidget.cc:148
+#: src/gui/layerwidget.cc:147
 msgid "uniform fill"
 msgstr "wypełnienie jednolite "
 
@@ -140,14 +142,17 @@ msgid "exporting"
 msgstr "eksportowanie"
 
 #: src/gui/imageeditor.cc:138 src/gui/imageeditor.cc:141
+#: src/gui/imageeditor.cc:142
 msgid "show merged layers"
 msgstr "pokaż scalone warstwy"
 
 #: src/gui/imageeditor.cc:139 src/gui/imageeditor.cc:142
+#: src/gui/imageeditor.cc:143
 msgid "show active layer"
 msgstr "pokaż warstwy aktywne"
 
 #: src/gui/imageeditor.cc:424 src/gui/imageeditor.cc:481
+#: src/gui/imageeditor.cc:485
 #, c-format
 msgid "Crash recovery found for file \"%s\". Do you want to restore it?"
 msgstr "Odzyskiwania po awarii, znaleziono plik \"%s\". Chcesz go przywrócić?"
@@ -161,35 +166,43 @@ msgid "Save"
 msgstr "Zapisz"
 
 #: src/gui/layerwidget.cc:115 src/gui/layerwidget.cc:181
+#: src/gui/layerwidget.cc:180
 msgid "Layers"
 msgstr "Warstwy"
 
 #: src/gui/layerwidget.cc:123 src/gui/layerwidget.cc:192
+#: src/gui/layerwidget.cc:191
 msgid "Add a new layer"
 msgstr "Dodaj nową warstwę"
 
 #: src/gui/layerwidget.cc:125 src/gui/layerwidget.cc:194
+#: src/gui/layerwidget.cc:193
 msgid "Add a new layer group"
 msgstr "Dodaj nową grupę warstw"
 
 #: src/gui/layerwidget.cc:127 src/gui/layerwidget.cc:196
+#: src/gui/layerwidget.cc:195
 msgid "Remove selected layers"
 msgstr "Usuń zaznaczone warstwy"
 
 #: src/gui/layerwidget.cc:129 src/gui/layerwidget.cc:198
+#: src/gui/layerwidget.cc:197
 msgid "Load an existing preset"
 msgstr "Wczytaj istniejący preset"
 
 #: src/gui/layerwidget.cc:130 src/gui/layerwidget.cc:200
+#: src/gui/layerwidget.cc:199
 msgid "Save the selected layers as a preset"
 msgstr "Zapisz zaznaczone warstwy jako preset"
 
 #: src/gui/layerwidget.cc:861 src/gui/layerwidget.cc:1250
+#: src/gui/layerwidget.cc:1249
 msgid "New Group Layer"
 msgstr "Nowa grupa warstw"
 
 #: src/gui/layerwidget.cc:871 src/gui/layerwidget.cc:986
-#: src/gui/layerwidget.cc:1260
+#: src/gui/layerwidget.cc:1260 src/gui/layerwidget.cc:985
+#: src/gui/layerwidget.cc:1259
 msgid "Group Layer Config"
 msgstr "Konfiguracja grupy warstw"
 
@@ -197,10 +210,13 @@ msgstr "Konfiguracja grupy warstw"
 #: src/gui/layerwidget.cc:969 src/gui/layerwidget.cc:974
 #: src/gui/layerwidget.cc:1290 src/gui/layerwidget.cc:1295
 #: src/gui/layerwidget.cc:1362 src/gui/layerwidget.cc:1367
+#: src/gui/layerwidget.cc:1289 src/gui/layerwidget.cc:1294
+#: src/gui/layerwidget.cc:1361 src/gui/layerwidget.cc:1366
 msgid "Photoflow presets"
 msgstr "Presety Photoflow"
 
 #: src/gui/layerwidget.cc:959 src/gui/layerwidget.cc:1352
+#: src/gui/layerwidget.cc:1351
 msgid "Save preset as..."
 msgstr "Zapisz preset jako..."
 
@@ -222,18 +238,21 @@ msgstr "Wyjście"
 
 #: src/gui/mainwindow.cc:359 src/gui/operationstree.cc:295
 #: src/gui/layerwidget.cc:683 src/gui/mainwindow.cc:552
+#: src/gui/layerwidget.cc:682
 msgid "Open image"
 msgstr "Otwórz obraz"
 
 #: src/gui/mainwindow.cc:374 src/gui/mainwindow.cc:385
 #: src/gui/layerwidget.cc:706 src/gui/layerwidget.cc:765
 #: src/gui/mainwindow.cc:567 src/gui/mainwindow.cc:625
+#: src/gui/layerwidget.cc:705 src/gui/layerwidget.cc:764
 msgid "Image files"
 msgstr "Pliki obrazu"
 
 #: src/gui/mainwindow.cc:380 src/gui/mainwindow.cc:391
 #: src/gui/layerwidget.cc:760 src/gui/layerwidget.cc:819
 #: src/gui/mainwindow.cc:620 src/gui/mainwindow.cc:678
+#: src/gui/layerwidget.cc:759 src/gui/layerwidget.cc:818
 msgid "All files"
 msgstr "Wszystkie pliki"
 
@@ -270,16 +289,19 @@ msgstr ""
 
 #: src/gui/operation_config_gui.cc:79 src/gui/operation_config_gui.cc:80
 #: src/gui/operation_config_gui.cc:86 src/gui/operation_config_gui.cc:87
+#: src/gui/operation_config_gui.cc:88
 msgid "Intensity"
 msgstr "Intensywność"
 
 #: src/gui/operation_config_gui.cc:81 src/gui/operation_config_gui.cc:82
 #: src/gui/operation_config_gui.cc:88 src/gui/operation_config_gui.cc:89
+#: src/gui/operation_config_gui.cc:90
 msgid "Opacity"
 msgstr "Krycie"
 
 #: src/gui/operation_config_gui.cc:83 src/gui/operation_config_gui.cc:84
 #: src/gui/operation_config_gui.cc:90 src/gui/operation_config_gui.cc:91
+#: src/gui/operation_config_gui.cc:92
 msgid "Enable mask"
 msgstr "Włącz maskę"
 
@@ -294,14 +316,17 @@ msgstr "Przesunięcie Y"
 #: src/gui/operation_config_gui.cc:88 src/gui/operation_config_gui.cc:89
 #: src/gui/operation_config_gui.cc:90 src/gui/operation_config_gui.cc:95
 #: src/gui/operation_config_gui.cc:96 src/gui/operation_config_gui.cc:97
+#: src/gui/operation_config_gui.cc:98
 msgid "Target channel: "
 msgstr "Kanał docelowy:"
 
 #: src/gui/operation_config_gui.cc:91 src/gui/operation_config_gui.cc:98
+#: src/gui/operation_config_gui.cc:99
 msgid "Target channel:"
 msgstr "Kanał docelowy:"
 
 #: src/gui/operation_config_gui.cc:92 src/gui/operation_config_gui.cc:99
+#: src/gui/operation_config_gui.cc:100
 msgid "preview"
 msgstr "podgląd"
 
@@ -353,11 +378,13 @@ msgstr "Nazwa warstwy:"
 
 #: src/gui/operations/hue_saturation_config.cc:85
 #: src/gui/operations/hue_saturation_config.cc:87
+#: src/gui/operations/brightness_contrast_config.cc:41
 msgid "Brightness"
 msgstr "Jasność"
 
 #: src/gui/operations/hue_saturation_config.cc:87
 #: src/gui/operations/hue_saturation_config.cc:89
+#: src/gui/operations/brightness_contrast_config.cc:42
 msgid "Contrast"
 msgstr "Kontrast"
 
@@ -443,7 +470,7 @@ msgid "Curves"
 msgstr "Krzywe"
 
 #: src/gui/operationstree.cc:307 src/gui/operationstree.cc:362
-#: src/gui/operationstree.cc:369
+#: src/gui/operationstree.cc:369 src/gui/operations/gradient_config.cc:48
 msgid "Invert"
 msgstr "Odwróć"
 
@@ -712,6 +739,7 @@ msgid "path mask"
 msgstr "maska ścieżki"
 
 #: src/operations/perspective.cc:51 src/gui/layerwidget.cc:154
+#: src/gui/layerwidget.cc:153
 msgid "perspective correction"
 msgstr "korekcja perspektywy"
 
@@ -735,95 +763,96 @@ msgstr "cienie/światła"
 msgid "updating"
 msgstr "aktualizacja"
 
-#: src/gui/imageeditor.cc:191
+#: src/gui/imageeditor.cc:191 src/gui/imageeditor.cc:192
 msgid "Toggle highlights clipping warning on/off"
 msgstr "Włączenie ostrzeżenia przycinania świateł on/off"
 
-#: src/gui/imageeditor.cc:195
+#: src/gui/imageeditor.cc:195 src/gui/imageeditor.cc:196
 msgid "Toggle shadows clipping warning on/off"
 msgstr "Włączenie ostrzegania przycinania cieni on/off"
 
-#: src/gui/imageeditor.cc:201
+#: src/gui/imageeditor.cc:201 src/gui/imageeditor.cc:202
 msgid "Zoom to 100%"
 msgstr "Powiększenie do 100%"
 
-#: src/gui/imageeditor.cc:205
+#: src/gui/imageeditor.cc:205 src/gui/imageeditor.cc:206
 msgid "Fit image to preview area"
 msgstr "Dopasuj obraz do obszaru podglądu"
 
-#: src/gui/imageeditor.cc:209
+#: src/gui/imageeditor.cc:209 src/gui/imageeditor.cc:210
 msgid "Zoom out"
 msgstr "Wyłącz powiększanie"
 
-#: src/gui/imageeditor.cc:213
+#: src/gui/imageeditor.cc:213 src/gui/imageeditor.cc:214
 msgid "Zoom in"
 msgstr "Włącz powiększanie"
 
-#: src/gui/imageeditor.cc:222
+#: src/gui/imageeditor.cc:222 src/gui/imageeditor.cc:223
 msgid "histogram"
 msgstr "histogram"
 
 #: src/gui/layerwidget.cc:116 src/gui/mainwindow.cc:100
+#: src/gui/layerwidget.cc:115
 msgid "New Adjustment"
 msgstr "Nowa regulacja"
 
-#: src/gui/layerwidget.cc:119
+#: src/gui/layerwidget.cc:119 src/gui/layerwidget.cc:118
 msgid "Load preset"
 msgstr "Ładuj preset"
 
-#: src/gui/layerwidget.cc:120
+#: src/gui/layerwidget.cc:120 src/gui/layerwidget.cc:119
 msgid "Save preset"
 msgstr "Zapisz preset "
 
-#: src/gui/layerwidget.cc:142
+#: src/gui/layerwidget.cc:142 src/gui/layerwidget.cc:141
 msgid "new layer"
 msgstr "nowa warstwa"
 
-#: src/gui/layerwidget.cc:143
+#: src/gui/layerwidget.cc:143 src/gui/layerwidget.cc:142
 msgid "new group layer"
 msgstr "nowa grupa warstw"
 
-#: src/gui/layerwidget.cc:144
+#: src/gui/layerwidget.cc:144 src/gui/layerwidget.cc:143
 msgid "delete layer"
 msgstr "usuń warstwę"
 
-#: src/gui/layerwidget.cc:145
+#: src/gui/layerwidget.cc:145 src/gui/layerwidget.cc:144
 msgid "insert image as layer"
 msgstr "wstaw obraz jako warstwę"
 
-#: src/gui/layerwidget.cc:146
+#: src/gui/layerwidget.cc:146 src/gui/layerwidget.cc:145
 msgid "basic editing"
 msgstr "podstawowa edycja"
 
-#: src/gui/layerwidget.cc:147
+#: src/gui/layerwidget.cc:147 src/gui/layerwidget.cc:146
 msgid "curves tool"
 msgstr "narzędzie krzywe"
 
-#: src/gui/layerwidget.cc:149
+#: src/gui/layerwidget.cc:149 src/gui/layerwidget.cc:148
 msgid "gradient tool"
 msgstr "narzędzie gradient"
 
-#: src/gui/layerwidget.cc:150
+#: src/gui/layerwidget.cc:150 src/gui/layerwidget.cc:149
 msgid "desaturate tool"
 msgstr "narzędzie desaturacja"
 
-#: src/gui/layerwidget.cc:151
+#: src/gui/layerwidget.cc:151 src/gui/layerwidget.cc:150
 msgid "crop tool"
 msgstr "narzędzie kadruj"
 
-#: src/gui/layerwidget.cc:153
+#: src/gui/layerwidget.cc:153 src/gui/layerwidget.cc:152
 msgid "clone stamp tool"
 msgstr "narzędzie stępel klonowania"
 
-#: src/gui/layerwidget.cc:155
+#: src/gui/layerwidget.cc:155 src/gui/layerwidget.cc:154
 msgid "scale/rotate tool"
 msgstr "narzędzie skalowanie/obracanie"
 
-#: src/gui/layerwidget.cc:156
+#: src/gui/layerwidget.cc:156 src/gui/layerwidget.cc:155
 msgid "path tool"
 msgstr "narzędzie ścieżka"
 
-#: src/gui/layerwidget.cc:976
+#: src/gui/layerwidget.cc:976 src/gui/layerwidget.cc:975
 msgid "RAW image"
 msgstr "RAW obraz"
 
@@ -864,39 +893,43 @@ msgstr "Otwórz okno dialogowe ustawienia"
 msgid "Exit PhotoFlow"
 msgstr "Wyjdź z PhotoFlow"
 
-#: src/gui/operation_config_gui.cc:92
+#: src/gui/operation_config_gui.cc:92 src/gui/operation_config_gui.cc:93
 msgid "X shift "
 msgstr "Przesunięcie X"
 
-#: src/gui/operation_config_gui.cc:93
+#: src/gui/operation_config_gui.cc:93 src/gui/operation_config_gui.cc:94
 msgid "Y shift "
 msgstr "Przesunięcie Y"
 
-#: src/gui/operation_config_gui.cc:253
+#: src/gui/operation_config_gui.cc:253 src/gui/operation_config_gui.cc:254
 msgid "toggle layer visibility on/off"
 msgstr "przełącznik widoczności warstwy wł / wył"
 
 #: src/gui/operation_config_gui.cc:254 src/gui/operation_config_gui.cc:255
+#: src/gui/operation_config_gui.cc:256
 msgid "enable/disable layer mask(s)"
 msgstr "włączanie/wyłączanie maski(ek) warstwy"
 
 #: src/gui/operation_config_gui.cc:256 src/gui/operation_config_gui.cc:257
+#: src/gui/operation_config_gui.cc:258
 msgid "toggle sticky flag on/off"
 msgstr "przełącznik znacznika przyczepienia on/off"
 
 #: src/gui/operation_config_gui.cc:258 src/gui/operation_config_gui.cc:259
+#: src/gui/operation_config_gui.cc:260
 msgid "toggle editing flag on/off"
 msgstr "przełącznik znacznika edycji on/off"
 
-#: src/gui/operation_config_gui.cc:260
+#: src/gui/operation_config_gui.cc:260 src/gui/operation_config_gui.cc:261
 msgid "reset tool parameters"
 msgstr "reset parametrów narzędzia"
 
 #: src/gui/operation_config_gui.cc:261 src/gui/operation_config_gui.cc:262
+#: src/gui/operation_config_gui.cc:263
 msgid "show information on current tool"
 msgstr "pokaż informacje o bieżącym narzędziu"
 
-#: src/gui/operation_config_gui.cc:707
+#: src/gui/operation_config_gui.cc:707 src/gui/operation_config_gui.cc:708
 msgid "Close"
 msgstr "Zamknij"
 
@@ -1164,3 +1197,253 @@ msgstr "typ profilu wyświetlacza:"
 #: src/gui/widgets/outmode_slider.cc:60
 msgid "preserve colors"
 msgstr "zachowaj kolory"
+
+#: src/base/image.cc:688
+msgid "background"
+msgstr ""
+
+#: src/base/pftypes.cc:56 src/base/pftypes.cc:65
+msgid "Passthrough"
+msgstr ""
+
+#: src/base/pftypes.cc:57 src/base/pftypes.cc:66
+msgid "Normal"
+msgstr ""
+
+#: src/base/pftypes.cc:59 src/base/pftypes.cc:68
+msgid "Grain extract"
+msgstr ""
+
+#: src/base/pftypes.cc:60 src/base/pftypes.cc:69
+msgid "Grain merge"
+msgstr ""
+
+#: src/base/pftypes.cc:61 src/base/pftypes.cc:70
+msgid "Overlay"
+msgstr ""
+
+#: src/base/pftypes.cc:63 src/base/pftypes.cc:72
+msgid "Soft light"
+msgstr ""
+
+#: src/base/pftypes.cc:64 src/base/pftypes.cc:73
+msgid "Hard light"
+msgstr ""
+
+#: src/base/pftypes.cc:65 src/base/pftypes.cc:74
+msgid "Vivid light"
+msgstr ""
+
+#: src/base/pftypes.cc:66 src/base/pftypes.cc:75
+msgid "Multiply"
+msgstr ""
+
+#: src/base/pftypes.cc:67 src/base/pftypes.cc:76
+#, fuzzy
+msgid "Screen"
+msgstr "Green"
+
+#: src/base/pftypes.cc:68 src/base/pftypes.cc:77
+#, fuzzy
+msgid "Lighten"
+msgstr "Jasność"
+
+#: src/base/pftypes.cc:69 src/base/pftypes.cc:78
+msgid "Darken"
+msgstr ""
+
+#: src/base/pftypes.cc:71 src/base/pftypes.cc:80
+msgid "Color"
+msgstr ""
+
+#: src/gui/settingsdialog.cc:67
+msgid "Color management"
+msgstr ""
+
+#: src/gui/settingsdialog.cc:68
+msgid "About"
+msgstr ""
+
+#: src/gui/settingsdialog.cc:212
+msgid "Please choose an ICC profile"
+msgstr ""
+
+#: src/operations/scale.cc:199
+msgid "Fit"
+msgstr ""
+
+#: src/operations/scale.cc:200
+msgid "percent"
+msgstr ""
+
+#: src/operations/scale.cc:217
+msgid "pixels"
+msgstr ""
+
+#: src/operations/scale.cc:218
+msgid "mm"
+msgstr ""
+
+#: src/operations/scale.cc:219
+msgid "cm"
+msgstr ""
+
+#: src/operations/scale.cc:220
+msgid "inches"
+msgstr ""
+
+#: src/gui/operations/clone_config.cc:38
+#, fuzzy
+msgid "Source channel: "
+msgstr "Kanał docelowy:"
+
+#: src/gui/operations/clone_stamp_config.cc:38
+msgid "Stamp size: "
+msgstr ""
+
+#: src/gui/operations/clone_stamp_config.cc:39
+msgid "Stamp opacity: "
+msgstr ""
+
+#: src/gui/operations/clone_stamp_config.cc:40
+msgid "Stamp smoothness: "
+msgstr ""
+
+#: src/gui/operations/clone_stamp_config.cc:41
+#: src/gui/operations/draw_config.cc:52
+msgid "Undo"
+msgstr ""
+
+#: src/gui/operations/uniform_config.cc:38
+msgid "Color:              "
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:46
+#, fuzzy
+msgid "Gradient tool"
+msgstr "narzędzie gradient"
+
+#: src/gui/operations/gradient_config.cc:47
+msgid "Type:) "
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:49
+msgid "Center X (%)"
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:50
+msgid "Center Y (%))"
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:38
+#, fuzzy
+msgid "Crop left"
+msgstr "Kadrowanie obrazu"
+
+#: src/gui/operations/crop_config.cc:39
+#, fuzzy
+msgid "Crop top"
+msgstr "narzędzie kadruj"
+
+#: src/gui/operations/crop_config.cc:40
+#, fuzzy
+msgid "Crop width"
+msgstr "Kadrowanie obrazu"
+
+#: src/gui/operations/crop_config.cc:41
+#, fuzzy
+msgid "Crop height"
+msgstr "Kadrowanie obrazu"
+
+#: src/gui/operations/crop_config.cc:42
+msgid "Keep aspect ratio"
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:43
+msgid "Aspect ratio: W="
+msgstr ""
+
+#: src/gui/operations/crop_config.cc:44
+msgid "/H="
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:47
+msgid "Type: "
+msgstr ""
+
+#: src/gui/operations/gradient_config.cc:50
+msgid "Center Y (%)"
+msgstr ""
+
+#: src/gui/operations/desaturate_config.cc:35
+#, fuzzy
+msgid "Desaturate method: "
+msgstr "narzędzie desaturacja"
+
+#: src/gui/operations/draw_config.cc:38
+msgid "Pen color:              "
+msgstr ""
+
+#: src/gui/operations/draw_config.cc:39
+msgid "Background color: "
+msgstr ""
+
+#: src/gui/operations/draw_config.cc:49
+msgid "Pen size: "
+msgstr ""
+
+#: src/gui/operations/draw_config.cc:50
+#, fuzzy
+msgid "Pen opacity: "
+msgstr "Krycie"
+
+#: src/gui/operations/draw_config.cc:51
+msgid "pen smoothness: "
+msgstr ""
+
+#: src/gui/operationstree.cc:208 src/gui/operation_config_gui.cc:688
+#: src/gui/operation_config_gui.cc:689
+msgid "This help is not yet available. Sorry."
+msgstr ""
+
+#: src/gui/layerwidget.cc:497 src/gui/layerwidget.cc:496
+#, fuzzy
+msgid "opacity ("
+msgstr "Krycie"
+
+#: src/gui/settingsdialog.cc:89
+msgid "Custom"
+msgstr ""
+
+#: src/gui/layerwidget.cc:1280 src/gui/layerwidget.cc:1279
+#, fuzzy
+msgid "Open preset"
+msgstr "Zapisz preset "
+
+#: src/gui/widgets/curveeditor.cc:42
+msgid "in: "
+msgstr ""
+
+#: src/gui/widgets/curveeditor.cc:43
+#, fuzzy
+msgid "out: "
+msgstr "wejście:"
+
+#: src/gui/operations/curves_config.cc:51
+#: src/gui/operations/brightness_contrast_config.cc:43
+msgid "Output mode"
+msgstr ""
+
+#: src/gui/operation_config_gui.cc:669 src/gui/operation_config_gui.cc:670
+msgid "help"
+msgstr ""
+
+#: src/gui/layerwidget.cc:449 src/gui/layerwidget.cc:448
+#, fuzzy
+msgid "intensity ("
+msgstr "Intensywność"
+
+#: src/gui/layerwidget.cc:964 src/gui/layerwidget.cc:963
+#, fuzzy
+msgid "image file"
+msgstr "Pliki obrazu"

--- a/src/base/image.cc
+++ b/src/base/image.cc
@@ -685,7 +685,7 @@ bool PF::Image::open( std::string filename, std::string bckname )
     if( proc->get_par() && proc->get_par()->get_property( "file_name" ) )
       proc->get_par()->get_property( "file_name" )->set_str( filename );
     limg->set_processor( proc );
-    limg->set_name( "background" );
+    limg->set_name( _("background") );
     layer_manager.get_layers().push_back( limg );
 
     file_name = filename;

--- a/src/base/pftypes.cc
+++ b/src/base/pftypes.cc
@@ -1,5 +1,5 @@
 #include "pftypes.hh"
-
+#include "photoflow.hh"
 
 template<PF::colorspace_t CS>
 int PF::ColorspaceInfo<CS>::NCH = 1;
@@ -53,22 +53,22 @@ PF::colorspace_t PF::convert_colorspace(VipsInterpretation interpretation)
 PF::Property<PF::blendmode_t>::Property(std::string name, PF::OpParBase* par): 
 PF::PropertyBase(name, par)
 {
-  add_enum_value(PF_BLEND_PASSTHROUGH,"PF_BLEND_PASSTHROUGH","Passthrough");
-  add_enum_value(PF_BLEND_NORMAL,"PF_BLEND_NORMAL","Normal");
+  add_enum_value(PF_BLEND_PASSTHROUGH,"PF_BLEND_PASSTHROUGH",_("Passthrough"));
+  add_enum_value(PF_BLEND_NORMAL,"PF_BLEND_NORMAL",_("Normal"));
   //add_enum_value(PF_BLEND_SEP1,"PF_BLEND_SEP1","Separator");
-  add_enum_value(PF_BLEND_GRAIN_EXTRACT,"PF_BLEND_GRAIN_EXTRACT","Grain extract");
-  add_enum_value(PF_BLEND_GRAIN_MERGE,"PF_BLEND_GRAIN_MERGE","Grain merge");
-  add_enum_value(PF_BLEND_OVERLAY,"PF_BLEND_OVERLAY","Overlay");
-  //add_enum_value(PF_BLEND_OVERLAY_GIMP,"PF_BLEND_OVERLAY_GIMP","Overlay (Gimp)");
-  add_enum_value(PF_BLEND_SOFT_LIGHT,"PF_BLEND_SOFT_LIGHT","Soft light");
-  add_enum_value(PF_BLEND_HARD_LIGHT,"PF_BLEND_HARD_LIGHT","Hard light");
-  add_enum_value(PF_BLEND_VIVID_LIGHT,"PF_BLEND_VIVID_LIGHT","Vivid light");
-  add_enum_value(PF_BLEND_MULTIPLY,"PF_BLEND_MULTIPLY","Multiply");
-  add_enum_value(PF_BLEND_SCREEN,"PF_BLEND_SCREEN","Screen");
-  add_enum_value(PF_BLEND_LIGHTEN,"PF_BLEND_LIGHTEN","Lighten");
-  add_enum_value(PF_BLEND_DARKEN,"PF_BLEND_DARKEN","Darken");
-  add_enum_value(PF_BLEND_LUMI,"PF_BLEND_LUMI","Luminosity");
-  add_enum_value(PF_BLEND_COLOR,"PF_BLEND_COLOR","Color");
+  add_enum_value(PF_BLEND_GRAIN_EXTRACT,"PF_BLEND_GRAIN_EXTRACT",_("Grain extract"));
+  add_enum_value(PF_BLEND_GRAIN_MERGE,"PF_BLEND_GRAIN_MERGE",_("Grain merge"));
+  add_enum_value(PF_BLEND_OVERLAY,"PF_BLEND_OVERLAY",_("Overlay"));
+  //add_enum_value(PF_BLEND_OVERLAY_GIMP,"PF_BLEND_OVERLAY_GIMP",_("Overlay (Gimp)"));
+  add_enum_value(PF_BLEND_SOFT_LIGHT,"PF_BLEND_SOFT_LIGHT",_("Soft light"));
+  add_enum_value(PF_BLEND_HARD_LIGHT,"PF_BLEND_HARD_LIGHT",_("Hard light"));
+  add_enum_value(PF_BLEND_VIVID_LIGHT,"PF_BLEND_VIVID_LIGHT",_("Vivid light"));
+  add_enum_value(PF_BLEND_MULTIPLY,"PF_BLEND_MULTIPLY",_("Multiply"));
+  add_enum_value(PF_BLEND_SCREEN,"PF_BLEND_SCREEN",_("Screen"));
+  add_enum_value(PF_BLEND_LIGHTEN,"PF_BLEND_LIGHTEN",_("Lighten"));
+  add_enum_value(PF_BLEND_DARKEN,"PF_BLEND_DARKEN",_("Darken"));
+  add_enum_value(PF_BLEND_LUMI,"PF_BLEND_LUMI",_("Luminosity"));
+  add_enum_value(PF_BLEND_COLOR,"PF_BLEND_COLOR",_("Color"));
   //set_enum_value(PF_BLEND_OV,"PF_BLEND_OV","Ov");
   //set_enum_value(PF_BLEND_OV,"PF_BLEND_OV","Ov");
   //set_enum_value(PF_BLEND_OV,"PF_BLEND_OV","Ov");

--- a/src/gui/layerwidget.cc
+++ b/src/gui/layerwidget.cc
@@ -26,7 +26,7 @@
   These files are distributed with PhotoFlow - http://aferrero2707.github.io/PhotoFlow/
 
 */
-
+#include <glib.h>
 
 #include "../base/file_util.hh"
 #include "../base/fileutils.hh"
@@ -36,7 +36,6 @@
 #include "tablabelwidget.hh"
 #include "layerwidget.hh"
 #include "imageeditor.hh"
-
 
 PF::ControlsGroup::ControlsGroup( ImageEditor* e ): editor(e)
 {
@@ -446,7 +445,7 @@ void PF::LayerWidget::on_row_activated( const Gtk::TreeModel::Path& path, Gtk::T
       */
 
       VTabLabelWidget* tabwidget = 
-        new VTabLabelWidget( std::string("intensity (")+l->get_name()+")",
+        new VTabLabelWidget( std::string(_("intensity ("))+l->get_name()+")",
                             view );
       tabwidget->signal_close.connect( sigc::mem_fun(*this, &PF::LayerWidget::remove_tab) ); 
       notebook.append_page( *view, *tabwidget );
@@ -494,7 +493,7 @@ void PF::LayerWidget::on_row_activated( const Gtk::TreeModel::Path& path, Gtk::T
       */
 
       VTabLabelWidget* tabwidget = 
-        new VTabLabelWidget( std::string("opacity (")+l->get_name()+")",
+        new VTabLabelWidget( std::string(_("opacity ("))+l->get_name()+")",
                             view );
       tabwidget->signal_close.connect( sigc::mem_fun(*this, &PF::LayerWidget::remove_tab) ); 
       notebook.append_page( *view, *tabwidget );
@@ -961,7 +960,7 @@ void PF::LayerWidget::insert_image( std::string filename )
     if( proc->get_par() && proc->get_par()->get_property( "file_name" ) )
       proc->get_par()->get_property( "file_name" )->set_str( filename );
     limg->set_processor( proc );
-    limg->set_name( "image file" );
+    limg->set_name( _("image file") );
 
     add_layer( limg );
   } else {
@@ -1277,7 +1276,7 @@ void PF::LayerWidget::on_button_del()
 
 void PF::LayerWidget::on_button_load()
 {
-  Gtk::FileChooserDialog dialog("Open preset",
+  Gtk::FileChooserDialog dialog(_("Open preset"),
 				Gtk::FILE_CHOOSER_ACTION_OPEN);
   //dialog.set_transient_for(*this);
   

--- a/src/gui/operation_config_gui.cc
+++ b/src/gui/operation_config_gui.cc
@@ -31,6 +31,7 @@
 #include "imageeditor.hh"
 
 #include "../base/new_operation.hh"
+#include "../base/photoflow.hh"
 
 #include "../gui/operations/raw_developer_config.hh"
 #include "../gui/operations/brightness_contrast_config.hh"
@@ -666,7 +667,7 @@ void PF::OperationConfigGUI::parameters_reset()
 
 void PF::OperationConfigGUI::show_help()
 {
-  Gtk::Dialog dialog("help", false);
+  Gtk::Dialog dialog(_("help"), false);
   dialog.set_default_size(300,100);
 
   Gtk::Frame frame;
@@ -685,7 +686,7 @@ void PF::OperationConfigGUI::show_help()
         if( !file.fail() ) help += ch;
       }
     } else {
-      help = "Ths help is not yet available. Sorry.";
+      help = _("This help is not yet available. Sorry.");
     }
   }
 

--- a/src/gui/operations/brightness_contrast_config.cc
+++ b/src/gui/operations/brightness_contrast_config.cc
@@ -38,9 +38,9 @@ PF::BrightnessContrastConfigGUI::BrightnessContrastConfigGUI( PF::Layer* layer )
   //contrastAdj( 0, -1, 1, 0.05, 0.2, 0),
   //brightnessScale(brightnessAdj),
   //contrastScale(contrastAdj)
-  brightnessSlider( this, "brightness", "Brightness", 0, -1, 1, 0.05, 0.2, 1),
-  contrastSlider( this, "contrast", "Contrast", 0, -1, 1, 0.05, 0.2, 1),
-  outputModeSlider( this, "color_blend", "Output mode", 0, -1, 1, 0.05, 0.2, 1)
+  brightnessSlider( this, "brightness", _("Brightness"), 0, -1, 1, 0.05, 0.2, 1),
+  contrastSlider( this, "contrast", _("Contrast"), 0, -1, 1, 0.05, 0.2, 1),
+  outputModeSlider( this, "color_blend", _("Output mode"), 0, -1, 1, 0.05, 0.2, 1)
 {
   //frame.add( controlsBox );
 

--- a/src/gui/operations/clone_config.cc
+++ b/src/gui/operations/clone_config.cc
@@ -35,7 +35,7 @@
 PF::CloneConfigGUI::CloneConfigGUI( PF::Layer* layer ):
   OperationConfigGUI( layer, "Clone layer" ),
   layer_list( this, "Layer name:"),
-  sourceSelector( this, "source_channel", "Source channel: ", 1 )
+  sourceSelector( this, "source_channel", _("Source channel: "), 1 )
 {
   add_widget( layer_list );
   add_widget( sourceSelector );

--- a/src/gui/operations/clone_stamp_config.cc
+++ b/src/gui/operations/clone_stamp_config.cc
@@ -35,10 +35,10 @@
 
 PF::CloneStampConfigGUI::CloneStampConfigGUI( PF::Layer* layer ):
   OperationConfigGUI( layer, "CloneStamp" ),
-  stamp_size( this, "stamp_size", "Stamp size: ", 5, 0, 1000000, 1, 10, 1),
-  stamp_opacity( this, "stamp_opacity", "Stamp opacity: ", 100, 0, 100, 0.1, 1, 100),
-  stamp_smoothness( this, "stamp_smoothness", "Stamp smoothness: ", 100, 0, 100, 0.1, 1, 100),
-  undoButton("Undo"),
+  stamp_size( this, "stamp_size", _("Stamp size: "), 5, 0, 1000000, 1, 10, 1),
+  stamp_opacity( this, "stamp_opacity", _("Stamp opacity: "), 100, 0, 100, 0.1, 1, 100),
+  stamp_smoothness( this, "stamp_smoothness", _("Stamp smoothness: "), 100, 0, 100, 0.1, 1, 100),
+  undoButton(_("Undo")),
   srcpt_row( 0 ), srcpt_col( 0 ), srcpt_ready( false ), srcpt_changed( false ), stroke_started( false )
 {
   controlsBox.pack_start( undoButton, Gtk::PACK_SHRINK );

--- a/src/gui/operations/crop_config.cc
+++ b/src/gui/operations/crop_config.cc
@@ -35,13 +35,13 @@
 PF::CropConfigGUI::CropConfigGUI( PF::Layer* layer ):
   OperationConfigGUI( layer, "Crop" ),
   handle( CROP_HANDLE_NONE ),
-  cropLeftSlider( this, "crop_left", "Crop left", 0, 0, 10000000, 1, 10, 1),
-  cropTopSlider( this, "crop_top", "Crop top", 0, 0, 10000000, 1, 10, 1),
-  cropWidthSlider( this, "crop_width", "Crop width", 0, 0, 10000000, 1, 10, 1),
-  cropHeightSlider( this, "crop_height", "Crop height", 0, 0, 10000000, 1, 10, 1),
-  keepARCheckBox( this, "keep_ar", "Keep aspect ratio", 0 ),
-  cropARWidthSlider( this, "ar_width", "Aspect ratio: W=", 0, 0, 10000000, 1, 10, 1),
-  cropARHeightSlider( this, "ar_height", "/H=", 0, 0, 10000000, 1, 10, 1)
+  cropLeftSlider( this, "crop_left", _("Crop left"), 0, 0, 10000000, 1, 10, 1),
+  cropTopSlider( this, "crop_top", _("Crop top"), 0, 0, 10000000, 1, 10, 1),
+  cropWidthSlider( this, "crop_width", _("Crop width"), 0, 0, 10000000, 1, 10, 1),
+  cropHeightSlider( this, "crop_height", _("Crop height"), 0, 0, 10000000, 1, 10, 1),
+  keepARCheckBox( this, "keep_ar", _("Keep aspect ratio"), 0 ),
+  cropARWidthSlider( this, "ar_width", _("Aspect ratio: W="), 0, 0, 10000000, 1, 10, 1),
+  cropARHeightSlider( this, "ar_height", _("/H="), 0, 0, 10000000, 1, 10, 1)
 {
   controlsBox.pack_start( cropLeftSlider );
   controlsBox.pack_start( cropTopSlider );

--- a/src/gui/operations/curves_config.cc
+++ b/src/gui/operations/curves_config.cc
@@ -48,7 +48,7 @@ PF::CurvesConfigGUI::CurvesConfigGUI(PF::Layer* layer):
   MCurveEditor( this, "M_curve", new PF::CurveArea(), 0, 100, 0, 100, CURVE_SIZE, CURVE_SIZE ),
   YCurveEditor( this, "Y_curve", new PF::CurveArea(), 0, 100, 0, 100, CURVE_SIZE, CURVE_SIZE ),
   KCurveEditor( this, "K_curve", new PF::CurveArea(), 0, 100, 0, 100, CURVE_SIZE, CURVE_SIZE ),
-  outputModeSlider( this, "color_blend", "Output mode", 0, 0, 1, 0.05, 0.2, 1)
+  outputModeSlider( this, "color_blend", _("Output mode"), 0, 0, 1, 0.05, 0.2, 1)
 {
 
   //rgbCurveSelector.init(); 

--- a/src/gui/operations/desaturate_config.cc
+++ b/src/gui/operations/desaturate_config.cc
@@ -32,7 +32,7 @@
 
 PF::DesaturateConfigGUI::DesaturateConfigGUI( PF::Layer* layer ):
   OperationConfigGUI( layer, "Desaturate" ),
-  modeSelector( this, "method", "Desaturate method: ", 0 )
+  modeSelector( this, "method", _("Desaturate method: "), 0 )
 {
   controlsBox.pack_start( modeSelector, Gtk::PACK_SHRINK );
   add_widget( controlsBox );

--- a/src/gui/operations/draw_config.cc
+++ b/src/gui/operations/draw_config.cc
@@ -35,8 +35,8 @@
 
 PF::DrawConfigGUI::DrawConfigGUI( PF::Layer* layer ):
   OperationConfigGUI( layer, "Draw" ),
-  pen_color_label("Pen color:              "),
-  bgd_color_label("Background color: "),
+  pen_color_label(_("Pen color:              ")),
+  bgd_color_label(_("Background color: ")),
 #ifdef GTKMM_2
   pen_color_button( Gdk::Color("white") ),
   bgd_color_button( Gdk::Color("black") ),
@@ -46,10 +46,10 @@ PF::DrawConfigGUI::DrawConfigGUI( PF::Layer* layer ):
   bgd_color_button( Gdk::RGBA("black") ),
 #endif
   bgd_transparent_checkbox( this, "bgd_transparent", _("transparent"), false ),
-  pen_size( this, "pen_size", "Pen size: ", 5, 0, 1000000, 1, 10, 1),
-  pen_opacity( this, "pen_opacity", "Pen opacity: ", 100, 0, 100, 0.1, 1, 100),
-  pen_smoothness( this, "pen_smoothness", "pen smoothness: ", 0, 0, 100, 1, 10, 100),
-  undoButton("Undo"), inhibit( false )
+  pen_size( this, "pen_size", _("Pen size: "), 5, 0, 1000000, 1, 10, 1),
+  pen_opacity( this, "pen_opacity", _("Pen opacity: "), 100, 0, 100, 0.1, 1, 100),
+  pen_smoothness( this, "pen_smoothness", _("pen smoothness: "), 0, 0, 100, 1, 10, 100),
+  undoButton(_("Undo")), inhibit( false )
 {
   colorButtonsBox1.pack_start( bgd_color_label, Gtk::PACK_SHRINK );
   colorButtonsBox1.pack_start( bgd_color_button, Gtk::PACK_SHRINK );

--- a/src/gui/operations/gradient_config.cc
+++ b/src/gui/operations/gradient_config.cc
@@ -43,11 +43,11 @@ static std::ostream& operator <<( std::ostream& str, const VipsRect& r )
 
 
 PF::GradientConfigGUI::GradientConfigGUI( PF::Layer* layer ):
-      OperationConfigGUI( layer, "Gradient tool" ),
-      typeSelector( this, "gradient_type", "Type: ", 1 ),
-      invert_box( this, "invert", "Invert", true ),
-      center_x( this, "gradient_center_x", "Center X (%)", 100, 0, 100, 1, 10, 100),
-      center_y( this, "gradient_center_y", "Center Y (%)", 100, 0, 100, 1, 10, 100),
+      OperationConfigGUI( layer, _("Gradient tool") ),
+      typeSelector( this, "gradient_type", _("Type: "), 1 ),
+      invert_box( this, "invert", _("Invert"), true ),
+      center_x( this, "gradient_center_x", _("Center X (%)"), 100, 0, 100, 1, 10, 100),
+      center_y( this, "gradient_center_y", _("Center Y (%)"), 100, 0, 100, 1, 10, 100),
       greyCurveEditor( this, "grey_curve", new PF::CurveArea(), 0, 100, 0, 100, CURVE_SIZE, CURVE_SIZE ),
       rgbCurveEditor( this, "RGB_curve", new PF::CurveArea(), 0, 100, 0, 100, CURVE_SIZE, CURVE_SIZE ),
       RCurveEditor( this, "R_curve", new PF::CurveArea(), 0, 100, 0, 100, CURVE_SIZE, CURVE_SIZE ),

--- a/src/gui/operations/uniform_config.cc
+++ b/src/gui/operations/uniform_config.cc
@@ -35,7 +35,7 @@
 
 PF::UniformConfigGUI::UniformConfigGUI( PF::Layer* layer ):
   OperationConfigGUI( layer, "Uniform" ),
-  color_label("Color:              "),
+  color_label(_("Color:              ")),
 #ifdef GTKMM_2
   color_button( Gdk::Color("white") )
 #endif

--- a/src/gui/operationstree.cc
+++ b/src/gui/operationstree.cc
@@ -106,12 +106,12 @@ void PF::OperationsTreeWidget::on_selection_changed()
     std::string op_type = (*iter)[columns.col_nickname];
     if( op_type == "curves" ) {
       buf->set_text("The curves tool allows to adjust the tonal range and colors of the image through control points.\n\n");
-      buf->insert_at_cursor("The tool provides a separate curve for each image channel. In the case of RGB images, ");
+      buf->insert_at_cursor("The tool provides a separate curve for each image channel. In the case of RGB images, "));
       buf->insert_at_cursor("an additional curve, called \"RGB\", allows to modify all three channels at the same time.\n\n");
       buf->insert_at_cursor("In the graphs, the horizontal axis represents the input values and the vertical axis the output ones.");
       buf->insert_at_cursor("The curve is initially a simple diagonal line, meaning that the output exactly matches input.\n\n");
       buf->insert_at_cursor("Left-clicking on the graph with the mouse adds a new control point, while right-clicking on an existing ");
-      buf->insert_at_cursor("control point deletes it. Control points can be moved by either dragging them with the moiuse, or by setting the corresponding input and output numerical values in the boxes below the graph.");
+      buf->insert_at_cursor("control point deletes it. Control points can be moved by either dragging them with the mouse, or by setting the corresponding input and output numerical values in the boxes below the graph.");
     }
      */
   }
@@ -205,7 +205,7 @@ void PF::OperationsTree::add_op( Glib::ustring name, const std::string nik)
       if( !file.fail() ) help += ch;
     }
   } else {
-    help = "Ths help is not yet available. Sorry.";
+    help = _("This help is not yet available. Sorry.");
   }
   row[columns.col_help] = help;
   PF::operations_help_map.insert( std::make_pair(nik, help) );

--- a/src/gui/settingsdialog.cc
+++ b/src/gui/settingsdialog.cc
@@ -64,8 +64,8 @@ PF::SettingsDialog::SettingsDialog():
   signal_response().connect( sigc::mem_fun(*this,
       &SettingsDialog::on_button_clicked) );
 
-  notebook.append_page( color_box, "Color management" );
-  notebook.append_page( about_box, "About" );
+  notebook.append_page( color_box, _("Color management") );
+  notebook.append_page( about_box, _("About") );
 
   cm_display_profile_model = Gtk::ListStore::create(cm_display_profile_columns);
   cm_display_profile_type_selector.set_model( cm_display_profile_model );
@@ -86,7 +86,7 @@ PF::SettingsDialog::SettingsDialog():
   ri = cm_display_profile_model->append();
   row = *(ri);
   row[cm_display_profile_columns.col_id] = 2;
-  row[cm_display_profile_columns.col_value] = "Custom";
+  row[cm_display_profile_columns.col_value] = _("Custom");
 
   //cm_display_profile_button.add( cm_display_profile_img );
   cm_display_profile_open_label.set_text( _("custom display profile name: ") );
@@ -209,7 +209,7 @@ void PF::SettingsDialog::on_button_clicked(int id)
 
 void PF::SettingsDialog::on_button_display_profile_open_clicked()
 {
-  Gtk::FileChooserDialog dialog("Please choose an ICC profile",
+  Gtk::FileChooserDialog dialog(_("Please choose an ICC profile"),
         Gtk::FILE_CHOOSER_ACTION_OPEN);
   //dialog.set_transient_for(*this);
 

--- a/src/gui/widgets/curveeditor.cc
+++ b/src/gui/widgets/curveeditor.cc
@@ -39,8 +39,8 @@ PF::CurveEditor::CurveEditor( OperationConfigGUI* dialog, std::string pname,
     int width, int height, int border_size ):
   Gtk::HBox(),
   PF::PFWidget( dialog, pname ),
-  xlabel( "in: " ),
-  ylabel( "out: " ),
+  xlabel( _("in: ") ),
+  ylabel( _("out: ") ),
   xmin( _xmin ), xmax( _xmax ), ymin( _ymin ), ymax( _ymax ),
 #ifdef GTKMM_2
   xadjustment( xmax, xmin, xmax, 1, 10, 0),

--- a/src/operations/scale.cc
+++ b/src/operations/scale.cc
@@ -196,8 +196,8 @@ PF::ScalePar::ScalePar():
       hflip("hflip",this,false),
       rotate_angle("rotate_angle",this,0),
       autocrop("autocrop",this,true),
-      scale_mode("scale_mode",this, SCALE_MODE_FIT, "SCALE_MODE_FIT", "Fit"),
-      scale_unit("scale_unit", this, SCALE_UNIT_PERCENT, "SCALE_UNIT_PERCENT", "percent"),
+      scale_mode("scale_mode",this, SCALE_MODE_FIT, "SCALE_MODE_FIT", _("Fit")),
+      scale_unit("scale_unit", this, SCALE_UNIT_PERCENT, "SCALE_UNIT_PERCENT", _("percent")),
       scale_width_pixels("scale_width_pixels",this,0),
       scale_height_pixels("scale_height_pixels",this,0),
       scale_width_percent("scale_width_percent",this,100),
@@ -214,10 +214,10 @@ PF::ScalePar::ScalePar():
   //scale_mode.add_enum_value( SCALE_MODE_FILL, "SCALE_MODE_FILL", "Fill" );
   //scale_mode.add_enum_value( SCALE_MODE_RESIZE, "SCALE_MODE_RESIZE", "Resize" );
 
-  scale_unit.add_enum_value( SCALE_UNIT_PX, "SCALE_UNIT_PX", "pixels" );
-  scale_unit.add_enum_value( SCALE_UNIT_MM, "SCALE_UNIT_MM", "mm" );
-  scale_unit.add_enum_value( SCALE_UNIT_CM, "SCALE_UNIT_CM", "cm" );
-  scale_unit.add_enum_value( SCALE_UNIT_INCHES, "SCALE_UNIT_INCHES", "inches" );
+  scale_unit.add_enum_value( SCALE_UNIT_PX, "SCALE_UNIT_PX", _("pixels") );
+  scale_unit.add_enum_value( SCALE_UNIT_MM, "SCALE_UNIT_MM", _("mm") );
+  scale_unit.add_enum_value( SCALE_UNIT_CM, "SCALE_UNIT_CM", _("cm") );
+  scale_unit.add_enum_value( SCALE_UNIT_INCHES, "SCALE_UNIT_INCHES", _("inches") );
 
   set_type( "scale" );
 

--- a/src/plugin/pfgimp.cc
+++ b/src/plugin/pfgimp.cc
@@ -72,9 +72,9 @@ MAIN()
 void query()
 {
   static const GimpParamDef args[] = {
-    {GIMP_PDB_INT32,    (gchar*)"run_mode", (gchar*)"Interactive, non-interactive"},
-    {GIMP_PDB_IMAGE,    (gchar*)"image",    (gchar*)"Input image"},
-    {GIMP_PDB_DRAWABLE, (gchar*)"drawable", (gchar*)"Input drawable (unused)"},
+    {GIMP_PDB_INT32,    (gchar*)"run_mode", (gchar*)_("Interactive, non-interactive")},
+    {GIMP_PDB_IMAGE,    (gchar*)"image",    (gchar*)_("Input image")},
+    {GIMP_PDB_DRAWABLE, (gchar*)"drawable", (gchar*)_("Input drawable (unused)")},
   };
 
   gimp_install_procedure("plug-in-photoflow",             // name
@@ -144,7 +144,7 @@ edit_current_layer_dialog()
   gtk_box_pack_start (GTK_BOX (hbox), main_vbox, FALSE, FALSE, 0);
   gtk_widget_show (main_vbox);
 
-  text = g_strdup ("This is a PhotoFlow layer.\nDo you want to continue\nediting this layer\nor create a new one?");
+  text = g_strdup _(("This is a PhotoFlow layer.\nDo you want to continue\nediting this layer\nor create a new one?"));
   label = gtk_label_new (text);
   g_free (text);
 

--- a/tools/po_update.sh
+++ b/tools/po_update.sh
@@ -10,8 +10,9 @@ for dir in $dirs; do
 done
 xgettext --from-code=UTF-8 --files-from=/tmp/sources.list --default-domain=photoflow -k_ --join-existing -o po/photoflow.pot
 
-langs="fr pl"
+langs="de fr pl"
 for lang in $langs; do
+    printf $lang: 
     msgmerge --output-file=po/${lang}.po po/${lang}.po po/photoflow.pot
 done
 #rm -f /tmp/sources.list


### PR DESCRIPTION
This pull request: 
- adds a German GUI translation,
- makes more GUI strings translatable,
- updates tools/po_update.sh to include the German translation and print out some information about the processed languages.

The changes to fr.po and pl.po are a side-effect of updating photoflow.pot. I changed no strings there.

To show the updated strings in the GUI, I had to add some includes to the following files:
base/pftypes.cc
gui/layerwidget.cc
gui/operation_config_gui.cc
Please check them to ensure that they match your software design.

The following strings could not be updated yet as there are some more prerequisites to do: 
photoflow.desktop
the GIMP plug-in

Anyway, good luck with this pull request!