### PR TITLE
Make it pass desktop-file-validate

### DIFF
--- a/data/photoflow.desktop
+++ b/data/photoflow.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=PhotoFlow
-_GenericName=RAW and bitmap photo editing
-_Comment=Edit images from digital cameras
+GenericName=RAW and bitmap photo editing
+Comment=Edit images from digital cameras
 
 X-GNOME-FullName=PhotoFlow Photo Editing Software
 
@@ -10,7 +10,7 @@ Version=1.0
 Type=Application
 Categories=Graphics;Photography;GTK;
 # TRANSLATORS: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-_Keywords=graphics;photography;raw;
+Keywords=graphics;photography;raw;
 
 Exec=photoflow %U
 TryExec=photoflow


### PR DESCRIPTION
Otherwise we are getting

```
photoflow.desktop: error: file contains key "_GenericName" in group "Desktop Entry", but key names must contain only the characters A-Za-z0-9- (they may have a "[LOCALE]" postfix)

photoflow.desktop: error: file contains key "_Comment" in group "Desktop Entry", but key names must contain only the characters A-Za-z0-9- (they may have a "[LOCALE]" postfix)

photoflow.desktop: error: file contains key "_Keywords" in group "Desktop Entry", but key names must contain only the characters A-Za-z0-9- (they may have a "[LOCALE]" postfix)
```

https://travis-ci.org/AppImage/AppImageHub/builds/266043504#L543-L546